### PR TITLE
feat: add support for multiple paths when using workspace mode

### DIFF
--- a/internal/backend/agent/prompt/engine.go
+++ b/internal/backend/agent/prompt/engine.go
@@ -316,7 +316,7 @@ func buildRequestContextUserInfoSection(requestContext *agentv1.RequestContext) 
 		lines = append(lines, "Shell: "+shell)
 	}
 	if workspacePaths := env.GetWorkspacePaths(); len(workspacePaths) > 0 {
-		lines = append(lines, "Workspace Path: "+strings.TrimSpace(workspacePaths[0]))
+		lines = append(lines, buildWorkspacePathsSection(workspacePaths))
 	}
 	isGitRepo := "Unknown"
 	repositoryInfo := requestContext.GetRepositoryInfo()
@@ -336,6 +336,32 @@ func buildRequestContextUserInfoSection(requestContext *agentv1.RequestContext) 
 		return ""
 	}
 	return "<user_info>\n" + strings.Join(lines, "\n\n") + "\n</user_info>"
+}
+
+// buildWorkspacePathsSection 构造工作区路径片段。
+//
+// 渲染规则：
+//   - 单路径：`Workspace Path: <path>`，与历史格式保持一致；
+//   - 多路径：`Workspace Paths:` 起行，后续每行以 `- <path>` 列出全部路径，顺序保留输入顺序。
+func buildWorkspacePathsSection(workspacePaths []string) string {
+	trimmedPaths := make([]string, 0, len(workspacePaths))
+	for _, path := range workspacePaths {
+		if path = strings.TrimSpace(path); path != "" {
+			trimmedPaths = append(trimmedPaths, path)
+		}
+	}
+	if len(trimmedPaths) == 0 {
+		return ""
+	}
+	if len(trimmedPaths) == 1 {
+		return "Workspace Path: " + trimmedPaths[0]
+	}
+	items := make([]string, 0, len(trimmedPaths)+1)
+	items = append(items, "Workspace Paths:")
+	for _, path := range trimmedPaths {
+		items = append(items, "- "+path)
+	}
+	return strings.Join(items, "\n")
 }
 
 // buildRequestContextAgentTranscriptsSection 构造 <agent_transcripts> 片段。


### PR DESCRIPTION
补充了workspace内多文件夹路径的系统prompt生成。
Is directory a git repo 对应的调整似乎比较麻烦，从cursor内拿到的数据只包括第一个文件夹的git状态。
不知道除了让byok自己去查git之外还有没有什么更好的办法
修改后效果如下
<img width="577" height="480" alt="图片" src="https://github.com/user-attachments/assets/fe606f0d-935a-4124-a687-64a0292a8499" />
