### PR TITLE
fix(openai): recognize MiMo in thinking disable

### DIFF
--- a/internal/backend/agent/model/openai.go
+++ b/internal/backend/agent/model/openai.go
@@ -1893,10 +1893,13 @@ func openAIThinkingDisableKind(baseURL string, modelID string, endpoint string) 
 		strings.Contains(base, "bigmodel") ||
 		strings.Contains(base, "z.ai") ||
 		strings.Contains(base, "zhipu") ||
+		strings.Contains(base, "xiaomimimo") ||
+		strings.Contains(base, "mimo") ||
 		strings.Contains(model, "deepseek") ||
 		strings.Contains(model, "glm") ||
 		strings.Contains(model, "zai") ||
-		strings.Contains(model, "zhipu"):
+		strings.Contains(model, "zhipu") ||
+		strings.Contains(model, "mimo"):
 		return "thinking_type"
 	case openAIModelSupportsReasoningNone(model):
 		return "reasoning_none"

--- a/internal/backend/agent/model/openai_thinking_disable_test.go
+++ b/internal/backend/agent/model/openai_thinking_disable_test.go
@@ -1,0 +1,84 @@
+package modeladapter
+
+import (
+	"testing"
+)
+
+// TestOpenAIThinkingDisableKindMiMo 验证小米 MiMo（base_url 含 xiaomimimo/mimo，
+// model 含 mimo）被识别为 thinking_type 分支，从而在用户禁用思考时正确写入
+// thinking:{type:"disabled"}。回归覆盖 deepseek/glm/qwen/gpt-5 等既有分支。
+func TestOpenAIThinkingDisableKindMiMo(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		modelID  string
+		endpoint string
+		want     string
+	}{
+		// MiMo —— 修复目标
+		{name: "mimo official base + pro model", baseURL: "https://api.xiaomimimo.com/v1", modelID: "mimo-v2.5-pro", endpoint: "/chat/completions", want: "thinking_type"},
+		{name: "mimo base by host keyword", baseURL: "https://api.xiaomimimo.com/v1", modelID: "mimo-v2.5", endpoint: "/chat/completions", want: "thinking_type"},
+		{name: "mimo model only (custom base)", baseURL: "https://custom.proxy.example.com/v1", modelID: "mimo-v2.5-pro", endpoint: "/chat/completions", want: "thinking_type"},
+		{name: "mimo ultraspeed variant", baseURL: "https://api.xiaomimimo.com/v1", modelID: "mimo-v2.5-pro-ultraspeed", endpoint: "/chat/completions", want: "thinking_type"},
+		// 回归：既有 thinking_type 分支不受影响
+		{name: "deepseek base", baseURL: "https://api.deepseek.com/v1", modelID: "deepseek-chat", endpoint: "/chat/completions", want: "thinking_type"},
+		{name: "glm model via zhipu base", baseURL: "https://open.bigmodel.cn/api/paas/v4", modelID: "glm-4.6", endpoint: "/chat/completions", want: "thinking_type"},
+		{name: "z.ai base", baseURL: "https://api.z.ai/api/paas/v4", modelID: "glm-4.5", endpoint: "/chat/completions", want: "thinking_type"},
+		// 回归：enable_thinking 分支（qwen 系）
+		{name: "qwen via dashscope", baseURL: "https://dashscope.aliyuncs.com/v1", modelID: "qwen-max", endpoint: "/chat/completions", want: "enable_thinking"},
+		{name: "qwen model keyword", baseURL: "https://custom.example.com/v1", modelID: "qwen3-coder", endpoint: "/chat/completions", want: "enable_thinking"},
+		// 回归：reasoning_none 分支（gpt-5.1+/gpt-6）
+		{name: "gpt-5.1", baseURL: "https://api.openai.com/v1", modelID: "gpt-5.1", endpoint: "/chat/completions", want: "reasoning_none"},
+		{name: "gpt-6", baseURL: "https://api.openai.com/v1", modelID: "gpt-6", endpoint: "/chat/completions", want: "reasoning_none"},
+		// 回归：未知 provider 不做 disable
+		{name: "unknown provider", baseURL: "https://api.unknown-llm.com/v1", modelID: "some-model", endpoint: "/chat/completions", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := openAIThinkingDisableKind(tc.baseURL, tc.modelID, tc.endpoint)
+			if got != tc.want {
+				t.Fatalf("openAIThinkingDisableKind(%q, %q, %q) = %q, want %q", tc.baseURL, tc.modelID, tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyOpenAIThinkingDisableMiMo 验证当 ThinkingEffort=disabled 且 provider
+// 为 MiMo 时，applyOpenAIThinkingDisable 会写入 thinking:{type:"disabled"} 并删除
+// reasoning_effort，与 deepseek/glm 行为一致。
+func TestApplyOpenAIThinkingDisableMiMo(t *testing.T) {
+	req := StreamRequest{ThinkingEffort: "disabled", RequestKnobs: map[string]any{}}
+	body := map[string]any{
+		"model":           "mimo-v2.5-pro",
+		"messages":        []map[string]any{{"role": "user", "content": "hi"}},
+		"reasoning_effort": "high",
+	}
+	applyOpenAIThinkingDisable(body, req, "https://api.xiaomimimo.com/v1", "mimo-v2.5-pro", "/chat/completions")
+
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected body[thinking] to be map[string]any, got %T (%v)", body["thinking"], body["thinking"])
+	}
+	if thinking["type"] != "disabled" {
+		t.Fatalf("expected thinking.type=disabled, got %v", thinking["type"])
+	}
+	if _, stillPresent := body["reasoning_effort"]; stillPresent {
+		t.Fatalf("reasoning_effort should be deleted when thinking disabled for mimo, got %v", body["reasoning_effort"])
+	}
+	if got := req.RequestKnobs["thinking_disabled_provider_param"]; got != "thinking.type" {
+		t.Fatalf("expected request knob thinking_disabled_provider_param=thinking.type, got %v", got)
+	}
+}
+
+// TestApplyOpenAIThinkingDisableMiMoNotTriggered 验证非 disabled 时不会误写 disable 字段。
+func TestApplyOpenAIThinkingDisableMiMoNotTriggered(t *testing.T) {
+	req := StreamRequest{ThinkingEffort: "high", RequestKnobs: map[string]any{}}
+	body := map[string]any{"model": "mimo-v2.5-pro", "reasoning_effort": "high"}
+	applyOpenAIThinkingDisable(body, req, "https://api.xiaomimimo.com/v1", "mimo-v2.5-pro", "/chat/completions")
+	if _, present := body["thinking"]; present {
+		t.Fatalf("thinking should not be injected when ThinkingEffort != disabled, got %v", body["thinking"])
+	}
+	if body["reasoning_effort"] != "high" {
+		t.Fatalf("reasoning_effort should be preserved when not disabled, got %v", body["reasoning_effort"])
+	}
+}


### PR DESCRIPTION
## Problem

`openAIThinkingDisableKind` (\`internal/backend/agent/model/openai.go\`) only matched these providers when disabling thinking:

- \`dashscope\` / \`qwen\` / \`aliyun\` → \`enable_thinking\`
- \`deepseek\` / \`bigmodel\` / \`z.ai\` / \`zhipu\` → \`thinking_type\`
- \`gpt-5.1+\` / \`gpt-6\` → \`reasoning_none\`

**Xiaomi MiMo** (\`api.xiaomimimo.com\`, model \`mimo-v2.5-pro\` / \`mimo-v2.5\` / \`mimo-v2.5-pro-ultraspeed\`) fell through to the \`default\` branch and returned \`""\`. As a result, when a user set \`reasoning=disabled\` (via CLI \`reasoning\`/\`thinking_intensity\` parameter, since the UI doesn't expose \`disabled\`), \`applyOpenAIThinkingDisable\` wrote **no disable field** into the request body, and MiMo kept thinking enabled — extra latency and reasoning-token cost contrary to the user's intent.

## Fix

MiMo uses the same \`thinking:{type:"disabled"}\` shape as deepseek/glm (confirmed in [MiMo docs](https://mimo.mi.com/docs/zh-CN/api/chat/openai-api)). Add \`xiaomimimo\` / \`mimo\` to the existing \`thinking_type\` case — 2 conditions, no new branch, no control-flow change.

\`\`\`go
case strings.Contains(base, "deepseek") ||
    ...
    strings.Contains(base, "xiaomimimo") ||   // new
    strings.Contains(base, "mimo") ||          // new
    ...
    strings.Contains(model, "mimo"):           // new
    return "thinking_type"
\`\`\`

Matching \`mimo\` on the **model** name is the robust anchor (model id always contains \`mimo\`); the base_url match covers \`api.xiaomimimo.com\` and tolerates future host changes.

## Tests

New \`openai_thinking_disable_test.go\`:
- \`openAIThinkingDisableKind\` returns \`"thinking_type"\` for MiMo (official base, host keyword, custom base + model-only, ultraspeed variant)
- Regressions: deepseek/glm/z.ai → \`thinking_type\`; qwen/dashscope → \`enable_thinking\`; gpt-5.1/gpt-6 → \`reasoning_none\`; unknown → \`""\`
- \`applyOpenAIThinkingDisable\` for MiMo writes \`thinking:{type:"disabled"}\`, deletes \`reasoning_effort\`, sets the \`thinking_disabled_provider_param\` knob
- Non-disabled effort does not inject \`thinking\`

## Verification

\`\`\`
go test ./internal/backend/agent/model/ -run ThinkingDisable   # PASS (14 cases)
go test ./internal/backend/agent/model/ ./internal/backend/forwarder/  # PASS
go vet ./internal/backend/agent/model/   # clean
go build ./internal/...   # OK
\`\`\`

## Risk

Minimal. Two \`strings.Contains\` conditions added to one case; no control-flow change. Only affects \`ThinkingEffort=disabled\` + MiMo provider. Worst case: a non-MiMo model whose id contains \`mimo\` would be routed to \`thinking_type\` — harmless (provider either honors \`thinking:{type:"disabled"}\` or ignores it).

## Scope

This PR only fixes the MiMo disable gap. A separate review found higher-severity issues in the Anthropic adapter (thinking-disable skipped on override path, cache-breakpoint/extra-params ordering) — those will go in follow-up PRs to keep this one minimal and reviewable.