### PR TITLE
docs(model-adapter): fix extra-params tooltip wording (merge→override)

### DIFF
--- a/frontend/src/components/ModelAdapterModal.vue
+++ b/frontend/src/components/ModelAdapterModal.vue
@@ -40,7 +40,7 @@ const openAIEndpointOptions = [
 ];
 
 const fieldTips = {
-  openAIExtraParams: "开启后会把 JSON 对象合并到 OpenAI 请求体。OpenAI service_tier 支持 auto、default、flex、scale、priority；priority 可用于高优先级/Fast 类场景。",
+  openAIExtraParams: "开启后会把 JSON 对象覆盖到 OpenAI 请求体。同名字段以这里为准。OpenAI service_tier 支持 auto、default、flex、scale、priority；priority 可用于高优先级/Fast 类场景。",
 };
 
 const props = defineProps({


### PR DESCRIPTION
## Problem

\`ModelAdapterModal.vue\` described the OpenAI extra-params field as \"**合并到** OpenAI 请求体\" (merge into the request body). The backend actually does override, not merge:

\`\`\`go
// internal/backend/agent/model/request_override.go:62-68
for key, value := range extraParams {
    body[name] = value   // direct assignment — same-name fields overridden
}
\`\`\`

This contradicted \`ModelEditor.vue:134\`, which correctly says \"**覆盖到** OpenAI 请求体。同名字段以这里为准\".

The misleading \"merge\" wording risked users expecting array fields like \`tools\` to be appended to the built-in function tools — in reality, writing \`{\"tools\":[...]}\` in extra params **replaces** the built-in tools array entirely, which would silently disable the agent's code tools (Read/Write/Shell/...).

## Fix

Align the modal tooltip with the editor view and the actual override semantics — 2 characters (\`合并\` → \`覆盖\`) plus the \"同名字段以这里为准\" qualifier that already appears in the editor tooltip.

## Risk

None — tooltip text only, no logic change.

## Verification

Manual diff review; frontend build not affected by a string-only change.