### PR TITLE
尝试修复使用claude模型无法识别图片问题

### DIFF
--- a/internal/backend/agent/model/anthropic.go
+++ b/internal/backend/agent/model/anthropic.go
@@ -156,6 +156,18 @@ func anthropicEndpointURL(baseURL string) string {
 	return base + "/v1/messages"
 }
 
+// shouldRelocateAnthropicImages 判断是否需要把图片块搬运到末条 user 消息。
+//
+// 官方 Anthropic 端点（api.anthropic.com）可正确处理任意位置的图片，保持原样；
+// 其余第三方中转站默认启用搬运，规避「非末尾图片被丢弃」的转换问题。
+func shouldRelocateAnthropicImages(baseURL string) bool {
+	base := strings.ToLower(strings.TrimSpace(baseURL))
+	if base == "" {
+		return false
+	}
+	return !strings.Contains(base, "api.anthropic.com")
+}
+
 // ApplyAnthropicCompatibleAuthHeaders 同时兼容 Anthropic 原生 x-api-key 和 Bearer token 代理。
 func ApplyAnthropicCompatibleAuthHeaders(httpReq *http.Request, apiKey string) {
 	if httpReq == nil {
@@ -215,8 +227,9 @@ func (adapter *AnthropicAdapter) Stream(ctx context.Context, req StreamRequest, 
 	body := cloneRequestBodyOverride(req.RequestBodyOverride)
 	if len(body) == 0 {
 		thinkingConfig := buildAnthropicThinkingConfig(req)
+		relocateImages := shouldRelocateAnthropicImages(baseURL)
 		stableMessageCount := anthropicStableProviderMessageCount(req.Messages, req.StableMessageCount, thinkingConfig != nil)
-		systemParts, messages, err := normalizeAnthropicProviderMessages(req.Messages, thinkingConfig != nil)
+		systemParts, messages, err := normalizeAnthropicProviderMessages(req.Messages, thinkingConfig != nil, relocateImages)
 		if err != nil {
 			return err
 		}
@@ -1066,7 +1079,7 @@ func anthropicStableProviderMessageCount(input []Message, stableReplayMessageCou
 	if len(stableReplayMessages) == 0 {
 		return 0
 	}
-	_, messages, err := normalizeAnthropicProviderMessages(stableReplayMessages, thinkingEnabled)
+	_, messages, err := normalizeAnthropicProviderMessages(stableReplayMessages, thinkingEnabled, false)
 	if err != nil {
 		return 0
 	}
@@ -1122,7 +1135,7 @@ func isAnthropicCacheableBlock(block map[string]any) bool {
 	}
 }
 
-func normalizeAnthropicProviderMessages(input []Message, thinkingEnabled bool) ([]string, []anthropicMessage, error) {
+func normalizeAnthropicProviderMessages(input []Message, thinkingEnabled bool, relocateImages bool) ([]string, []anthropicMessage, error) {
 	systemParts := make([]string, 0, len(input))
 	messages := make([]anthropicMessage, 0, len(input))
 	pendingToolResults := make([]map[string]any, 0, 2)
@@ -1208,7 +1221,68 @@ func normalizeAnthropicProviderMessages(input []Message, thinkingEnabled bool) (
 		}
 	}
 	flushToolResults()
+	if relocateImages {
+		messages = relocateAnthropicImagesToLastUserMessage(messages)
+	}
 	return systemParts, messages, nil
+}
+
+// relocateAnthropicImagesToLastUserMessage 把所有 user 消息里的 image 块搬运到最后一条 user 消息的末尾。
+//
+// 背景：部分第三方中转站（如 Bedrock 代理）在 Anthropic→上游 的消息转换中，
+// 会丢弃「后面还跟着大量文本/消息」的非末尾图片块。将图片统一移动到末条 user 消息
+// 可规避该问题，同时保留图片信息本身。
+//
+// 数据流演变：
+//
+//	[user_info] [query + IMG] [reminder] [reminder] [current_request]
+//	→ [user_info] [query] [reminder] [reminder] [current_request + IMG]
+//
+// 搬运后若某条 user 消息 content 变空，则丢弃该消息，避免 Anthropic 拒绝空内容消息。
+func relocateAnthropicImagesToLastUserMessage(messages []anthropicMessage) []anthropicMessage {
+	lastUserIndex := -1
+	for index := len(messages) - 1; index >= 0; index-- {
+		if strings.TrimSpace(messages[index].Role) == "user" {
+			lastUserIndex = index
+			break
+		}
+	}
+	if lastUserIndex < 0 {
+		return messages
+	}
+
+	relocated := make([]map[string]any, 0, 2)
+	for index := 0; index < len(messages); index++ {
+		if index == lastUserIndex || strings.TrimSpace(messages[index].Role) != "user" {
+			continue
+		}
+		kept := make([]map[string]any, 0, len(messages[index].Content))
+		for _, block := range messages[index].Content {
+			if isAnthropicImageBlock(block) {
+				relocated = append(relocated, block)
+				continue
+			}
+			kept = append(kept, block)
+		}
+		messages[index].Content = kept
+	}
+	if len(relocated) == 0 {
+		return messages
+	}
+	messages[lastUserIndex].Content = append(messages[lastUserIndex].Content, relocated...)
+
+	compacted := make([]anthropicMessage, 0, len(messages))
+	for index, message := range messages {
+		if index != lastUserIndex && strings.TrimSpace(message.Role) == "user" && len(message.Content) == 0 {
+			continue
+		}
+		compacted = append(compacted, message)
+	}
+	return compacted
+}
+
+func isAnthropicImageBlock(block map[string]any) bool {
+	return strings.TrimSpace(anthropicStringField(block, "type")) == "image"
 }
 
 func anthropicProviderContentBlocks(message Message, thinkingEnabled bool) ([]map[string]any, error) {


### PR DESCRIPTION
#185 

通过AI排查到了使用claude模型无法识别图片的原因: 图片块后面跟着大量文本/消息时，中转站在 Anthropic→Bedrock 转换中把 image 块丢了；图片在末尾或后面内容很少时正常。这也是为什么直接curl接口带图片会没有问题。修复方向是将图片拼到最后一条消息内。本人不太懂go，所以用ai写了一些解决方案，大佬可以按思路修改。

决定性结果。**全部 5 个探针都成功**了，包括 `q1-H`——它和之前失败的 `H-only2msgs` 结构几乎一致（`[巨型t24190] + [文本+IMG]`），这次却成功了。

这把 H 的谜题解开了，也让整条证据链收敛到一个连贯的结论。

## 根因：中转站在「图片块后面还有大量内容」时会丢弃图片

把所有测试按「图片后面还有多少内容」重新排列，规律非常干净：

| 用例 | 图片后面的内容 | 结果 |
|---|---|---|
| `moreuser2` | 9 字符（1条小消息） | ✅ |
| `I` / `J` / `q1~q5` | 0（图片在末尾） | ✅ |
| **真实失败请求** | system_reminder + current_user_request（≈800字符，3条消息） | ❌ |
| `G` / `K` / `F-minimal` | ≈791 字符（3条消息） | ❌ |

规律：**图片块后面跟着大量文本/消息时，中转站在 Anthropic→Bedrock 转换中把 image 块丢了；图片在末尾或后面内容很少时正常。**

- `H` 那次失败是唯一噪点——结构近乎相同的 `q1-H` 这次成功了。结合中转站开了 prompt 缓存（之前 usage 里 `cache_read_input_tokens: 29363`），`H` 那次大概率是**缓存态的瞬时抖动**，不是稳定的结构规则。我不把它当作确定性因素。

这也解释了全部现象：

```text
Cursor 真实请求的消息顺序：
  [0] user_info
  [1] user_query + 图片        ← 图片在这
  [2] system_reminder          ┐
  [3] system_reminder          ├ 图片后面压了 ≈800 字符
  [4] current_user_request     ┘
→ 中转站转 Bedrock 时，图片块后面还有大量内容 → 图片被丢 → "看不到图"

GPT 走 OpenAI Responses 路径，不经过这个转换 → 不受影响 → 正常
```

`J` 直接验证了修复方向：把**失败请求的图片挪到最后一条消息**，立刻成功。

## 诚实边界

「图片后面内容多就丢图」是中转站内部行为，我看不到它的转换代码，无法 100% 断言其内部机制（可能是多部分内容序列化 bug，也可能叠加了缓存）。但从可复现角度，**「图片不在末尾/后面跟大量内容」是触发失败的稳定条件**，`J` 证明「把图片移到末尾」能稳定修复。

## 修复方向（落到代理模块职责）

问题不在中转站（你改不了），能改的是**代理发出的消息布局**。修复点在 `normalizeAnthropicProviderMessages`——它目前逐条透传消息，导致 Cursor 把图片夹在早期消息、后面还跟着 reminder 的布局被原样发出。

修复思路（`J` 已验证有效）：**在归一化时，把所有 image 块搬运到最后一条 user 消息的末尾**。

```text
# 伪代码：normalizeAnthropicProviderMessages 收尾处
收集所有 user 消息里的 image 块 → images[]
从原位置移除这些 image 块
将 images[] 追加到「最后一条 user 消息」的 content 末尾

# 效果：
#   [user_info] [query+IMG] [reminder] [reminder] [current_request]
# → [user_info] [query] [reminder] [reminder] [current_request + IMG]
#   图片位于整个请求末尾 → 中转站不再丢图
```

这属于「投影层把消息布局适配到 provider/中转站能正确处理的形态」的职责，放在 `normalizeAnthropicProviderMessages` 里最合适。需要注意一个语义权衡：移动图片位置会让图片和它原本的上下文文字分离，但实测中转站本就把非末尾图片丢弃，两害相权，移到末尾能保住图片信息，是净收益。

要我直接在 `normalizeAnthropicProviderMessages` 里实现「image 块搬运到末条 user 消息」吗？我会加一个开关（仅对第三方中转站端点生效，官方 Anthropic 端点保持原样），避免影响正常直连 Anthropic 的场景。

