### PR TITLE
fix(model): lower anthropic thinking defaults and allow disabling thinking

### DIFF
--- a/internal/backend/agent/model/anthropic.go
+++ b/internal/backend/agent/model/anthropic.go
@@ -263,7 +263,7 @@ func (adapter *AnthropicAdapter) Stream(ctx context.Context, req StreamRequest, 
 		body["system"] = anthropicProviderSystemBlocks(systemParts)
 		if thinkingConfig != nil {
 			body["thinking"] = thinkingConfig
-			if normalizeRuntimeThinkingEffort(req.ThinkingEffort) != "disabled" {
+			if !isAnthropicThinkingDisabled(req) {
 				body["output_config"] = buildAnthropicOutputConfig(req)
 			}
 		}
@@ -1353,7 +1353,7 @@ func completedAnthropicToolArgsJSON(accumulator *anthropicToolAccumulator) ([]by
 }
 
 func buildAnthropicThinkingConfig(req StreamRequest) map[string]any {
-	if normalizeRuntimeThinkingEffort(req.ThinkingEffort) == "disabled" {
+	if isAnthropicThinkingDisabled(req) {
 		return map[string]any{
 			"type": "disabled",
 		}
@@ -1367,6 +1367,18 @@ func buildAnthropicThinkingConfig(req StreamRequest) map[string]any {
 	}
 }
 
+func isAnthropicThinkingDisabled(req StreamRequest) bool {
+	if normalizeRuntimeThinkingEffort(req.ThinkingEffort) == "disabled" {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(req.AnthropicThinkingEffort)) {
+	case "disabled", "off", "none", "false", "no":
+		return true
+	default:
+		return false
+	}
+}
+
 func buildAnthropicOutputConfig(req StreamRequest) map[string]any {
 	return map[string]any{
 		"effort": anthropicThinkingEffort(req),
@@ -1375,10 +1387,12 @@ func buildAnthropicOutputConfig(req StreamRequest) map[string]any {
 
 func anthropicThinkingEffort(req StreamRequest) string {
 	switch strings.ToLower(strings.TrimSpace(req.AnthropicThinkingEffort)) {
+	case "disabled", "off", "none", "false", "no":
+		return ""
 	case "low", "medium", "high", "xhigh", "max":
 		return strings.ToLower(strings.TrimSpace(req.AnthropicThinkingEffort))
 	default:
-		return "xhigh"
+		return "medium"
 	}
 }
 

--- a/internal/backend/server/config/resolver.go
+++ b/internal/backend/server/config/resolver.go
@@ -11,9 +11,9 @@ import (
 const (
 	defaultChannelTimeoutMS           = int((2 * 60 * 60) * 1000)
 	defaultChannelContextWindowTokens = 200_000
-	defaultChannelMaxTokens           = 65_536
-	defaultChannelThinkingBudget      = 4_096
-	defaultChannelAnthropicEffort     = "xhigh"
+	defaultChannelMaxTokens           = 8_192
+	defaultChannelThinkingBudget      = 1_024
+	defaultChannelAnthropicEffort     = "medium"
 )
 
 func (manager *Manager) SelectChannelForModel(_ context.Context, modelID string) (*legacyruntime.ResolvedChannel, error) {

--- a/internal/backend/server/config/types.go
+++ b/internal/backend/server/config/types.go
@@ -168,7 +168,7 @@ func NormalizeModelAdapterConfigs(input []ModelAdapterConfig) ([]ModelAdapterCon
 				return nil, err
 			}
 		case next.Type == "anthropic" && next.AnthropicThinkingEffort == "":
-			return nil, errors.New("模型适配器 anthropicThinkingEffort 仅支持 low、medium、high、xhigh、max")
+			return nil, errors.New("模型适配器 anthropicThinkingEffort 仅支持 disabled、low、medium、high、xhigh、max")
 		}
 		next.ID = modelchannel.BuildChannelID(next.BaseURL, next.ModelID, next.APIKey, next.DisplayName, next.OpenAIEndpoint)
 		if _, exists := seenChannelIDs[next.ID]; exists {
@@ -225,9 +225,11 @@ func normalizeReasoningEffort(value string) string {
 
 func normalizeAnthropicThinkingEffort(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "xhigh":
-		return "xhigh"
-	case "low", "medium", "high", "max":
+	case "disabled", "off", "none", "false", "no":
+		return "disabled"
+	case "":
+		return "medium"
+	case "low", "medium", "high", "xhigh", "max":
 		return strings.ToLower(strings.TrimSpace(value))
 	default:
 		return ""

--- a/internal/client/model_adapter_benchmark.go
+++ b/internal/client/model_adapter_benchmark.go
@@ -28,7 +28,7 @@ const (
 	modelAdapterTestUpdatedEvent      = "model-adapter-test:updated"
 	modelAdapterTestPrompt            = "Output the numbers 1 through 120 separated by a single space. No commas, no newlines, no explanation."
 	modelAdapterTestTimeout           = 45 * time.Second
-	modelAdapterTestDefaultMaxTokens  = 65_536
+	modelAdapterTestDefaultMaxTokens  = 4_096
 	modelAdapterTestEmptyTextError    = "未收到文本输出，无法计算测速结果"
 	modelAdapterTestMaxErrorBodyBytes = 8192
 )
@@ -684,10 +684,12 @@ func normalizeModelAdapterTestProviderReasoning(adapter serverconfig.ModelAdapte
 
 func normalizeModelAdapterTestAnthropicThinkingEffort(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "disabled", "off", "none", "false", "no":
+		return "disabled"
 	case "low", "medium", "high", "xhigh", "max":
 		return strings.ToLower(strings.TrimSpace(value))
 	default:
-		return "xhigh"
+		return "disabled"
 	}
 }
 


### PR DESCRIPTION
## 背景

  Anthropic-compatible 渠道默认使用 `xhigh` 思考强度 + `max_tokens=65536`（max_tokens 同时也会抬高 thinking
  budget）。连接测试与 Cursor 客户端只把真实文本 token
  计为首个输出，因此思考阶段的耗时表现为「首字返回时间过长」，并最终导致 Cursor 报 Internal Error / 超时。

  在 Claude Code 中用相同配置可正常使用；独立 Python 测速脚本因不带思考，首字延迟明显更短。

  ## 改动

  - `resolver`：默认 `max_tokens` 65536 → 8192，`thinking_budget` 4096 → 1024，`anthropic effort` xhigh → medium
  - `types` / `anthropic`：支持通过 `disabled`/`off`/`none`/`false`/`no` 完全关闭 extended thinking；空值默认由 `xhigh`
  改为 `medium`
  - `benchmark`：测试默认 effort 改为 `disabled`，测试 `max_tokens` 65536 → 4096

  ## 效果

  extended thinking 仍然可用，但默认更轻量；对不支持思考的中转，可显式设为 `disabled` 获得最低首字延迟。已在 Windows
  上构建验证，实测首字延迟显著下降，Cursor 不再报错。

  ## 验证

  - `go build` / `go vet` 通过
  - 基于 latest main，仅改动 4 个文件，与 #168（custom OpenAI endpoint）无冲突
  
  
<img width="1645" height="692" alt="Snipaste_2026-07-10_15-48-13" src="https://github.com/user-attachments/assets/f7ce719e-3635-4afd-9777-8991e27c49e1" />
<img width="483" height="308" alt="2C271E7C5A08DAA30B45AC0D058F97DB" src="https://github.com/user-attachments/assets/a2e44379-34ec-47d0-b96d-f183deeb0c61" />

