### PR TITLE
fix(forwarder): 修复 Fork Chat 会话恢复

### DIFF
--- a/internal/backend/agent/protocol/inbound.go
+++ b/internal/backend/agent/protocol/inbound.go
@@ -37,13 +37,33 @@ func NormalizeRequestID(requestID string) string {
 
 // DecodeAgentClientMessage 解析 hex 文本为 AgentClientMessage，并返回消息类型标签。
 func DecodeAgentClientMessage(hexData string) (*agentv1.AgentClientMessage, string, error) {
+	message, kind, _, err := DecodeAgentClientMessagePayload(hexData, nil)
+	return message, kind, err
+}
+
+// DecodeAgentClientMessagePayload accepts both the legacy hex field and the
+// binary field used by newer Cursor clients. Binary takes precedence when set.
+func DecodeAgentClientMessagePayload(hexData string, binaryData []byte) (*agentv1.AgentClientMessage, string, []byte, error) {
+	if len(binaryData) > 0 {
+		payload := append([]byte(nil), binaryData...)
+		message, kind, err := DecodeAgentClientMessageBytes(payload)
+		return message, kind, payload, err
+	}
 	trimmed := strings.TrimSpace(hexData)
 	if trimmed == "" {
-		return nil, "", nil
+		return nil, "", nil, nil
 	}
 	payload, err := hex.DecodeString(trimmed)
 	if err != nil {
-		return nil, "", fmt.Errorf("bidi append data is not valid hex: %w", err)
+		return nil, "", nil, fmt.Errorf("bidi append data is not valid hex: %w", err)
+	}
+	message, kind, err := DecodeAgentClientMessageBytes(payload)
+	return message, kind, payload, err
+}
+
+func DecodeAgentClientMessageBytes(payload []byte) (*agentv1.AgentClientMessage, string, error) {
+	if len(payload) == 0 {
+		return nil, "", nil
 	}
 	clientMessage := &agentv1.AgentClientMessage{}
 	if err := proto.Unmarshal(payload, clientMessage); err != nil {

--- a/internal/backend/forwarder/actor.go
+++ b/internal/backend/forwarder/actor.go
@@ -129,12 +129,15 @@ func (service *Service) dispatchInboundIntent(intent InboundIntent) error {
 	if service == nil {
 		return fmt.Errorf("forwarder service is nil")
 	}
-	stream, err := service.streamForIntent(intent)
+	stream, runSetupGeneration, err := service.streamForIntent(intent)
 	if err != nil {
 		return err
 	}
 	if stream == nil {
 		return nil
+	}
+	if strings.TrimSpace(intent.Kind) == "run" {
+		intent.RunSetupGeneration = runSetupGeneration
 	}
 	commandKind, err := commandKindForIntent(intent)
 	if err != nil {
@@ -146,7 +149,7 @@ func (service *Service) dispatchInboundIntent(intent InboundIntent) error {
 	})
 }
 
-func (service *Service) streamForIntent(intent InboundIntent) (*ActiveStream, error) {
+func (service *Service) streamForIntent(intent InboundIntent) (*ActiveStream, uint64, error) {
 	switch strings.TrimSpace(intent.Kind) {
 	case "run":
 		stream, err := service.broker.OpenStream(
@@ -159,33 +162,33 @@ func (service *Service) streamForIntent(intent InboundIntent) (*ActiveStream, er
 			userMessageText(intent.UserMessage),
 		)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if stream == nil {
-			return nil, fmt.Errorf("open stream failed")
+			return nil, 0, fmt.Errorf("open stream failed")
 		}
-		return stream, nil
+		return stream, service.beginRunSetup(stream, intent.RunIngressGeneration), nil
 	case "metadata", "kv_result":
 		stream, ok := service.broker.Get(intent.RequestID)
 		if !ok || stream == nil {
 			if intent.HasExplicitMode || intent.StartsRun {
-				return nil, fmt.Errorf("metadata intent requires active request context: %s", intent.RequestID)
+				return nil, 0, fmt.Errorf("metadata intent requires active request context: %s", intent.RequestID)
 			}
-			return nil, nil
+			return nil, 0, nil
 		}
 		if isTerminalIntentStream(stream) {
-			return nil, nil
+			return nil, 0, nil
 		}
-		return stream, nil
+		return stream, 0, nil
 	default:
 		stream, ok := service.broker.Get(intent.RequestID)
 		if !ok || stream == nil {
-			return nil, fmt.Errorf("request is not active: %s", intent.RequestID)
+			return nil, 0, fmt.Errorf("request is not active: %s", intent.RequestID)
 		}
 		if isTerminalIntentStream(stream) {
-			return nil, nil
+			return nil, 0, nil
 		}
-		return stream, nil
+		return stream, 0, nil
 	}
 }
 
@@ -314,7 +317,7 @@ func shouldStopStreamActor(stream *ActiveStream) bool {
 func (service *Service) handleStreamCommand(stream *ActiveStream, command streamCommand) error {
 	switch command.Kind {
 	case streamCommandRun:
-		return service.handleRunIntent(command.Intent)
+		return service.handleRunIntent(stream, command.Intent)
 	case streamCommandCancel:
 		return service.handleCancelIntent(command.Intent)
 	case streamCommandMetadata:

--- a/internal/backend/forwarder/append_seq.go
+++ b/internal/backend/forwarder/append_seq.go
@@ -8,7 +8,10 @@ import (
 	"time"
 )
 
-const appendSequenceRetention = 10 * time.Minute
+const (
+	appendSequenceRetention = 10 * time.Minute
+	maxAppendSequence       = int64(1<<63 - 1)
+)
 
 type appendSequenceTracker struct {
 	mu     sync.Mutex
@@ -16,16 +19,40 @@ type appendSequenceTracker struct {
 }
 
 type appendSequenceState struct {
-	mu         sync.Mutex
-	next       int64
-	processing bool
-	ready      chan struct{}
-	updatedAt  time.Time
+	mu                               sync.Mutex
+	next                             int64
+	processing                       bool
+	ready                            chan struct{}
+	completed                        map[int64]struct{}
+	restartGeneration                uint64
+	acceptedFingerprints             map[int64][32]byte
+	sequenceZeroReplayPending        bool
+	sequenceZeroReplayGeneration     uint64
+	sequenceZeroReplayBaseNext       int64
+	sequenceZeroReplayChangeObserved bool
+	replayDuplicateFingerprints      map[int64][32]byte
+	replayBaselineFingerprints       map[int64][32]byte
+	replayBaselineExclusiveSequence  int64
+	updatedAt                        time.Time
+}
+
+type appendSequenceGeneration struct {
+	state             *appendSequenceState
+	restartGeneration uint64
 }
 
 type appendSequenceTicket struct {
-	state *appendSequenceState
-	seq   int64
+	state           *appendSequenceState
+	seq             int64
+	generation      appendSequenceGeneration
+	replayRestarted bool
+}
+
+type appendSequenceCompletion struct {
+	stale           bool
+	retry           bool
+	generation      appendSequenceGeneration
+	replayRestarted bool
 }
 
 func newAppendSequenceTracker() *appendSequenceTracker {
@@ -34,19 +61,64 @@ func newAppendSequenceTracker() *appendSequenceTracker {
 	}
 }
 
+// Acquire preserves the original one-based tracker API used by existing
+// callers. Production Bidi traffic uses AcquireForTransport because the
+// current client transport is zero-based.
 func (tracker *appendSequenceTracker) Acquire(ctx context.Context, requestID string, appendSeq int64) (appendSequenceTicket, bool, error) {
-	if tracker == nil || strings.TrimSpace(requestID) == "" || appendSeq <= 0 {
+	requestID = strings.TrimSpace(requestID)
+	if tracker == nil || requestID == "" || appendSeq <= 0 {
+		return appendSequenceTicket{}, false, nil
+	}
+	state := tracker.state(requestID)
+	allowRestart := false
+	if appendSeq == 1 {
+		state.mu.Lock()
+		next := state.next
+		state.mu.Unlock()
+		if next > 0 {
+			allowRestart = true
+		}
+	}
+	return tracker.acquireState(ctx, requestID, appendSeq-1, allowRestart)
+}
+
+func (tracker *appendSequenceTracker) AcquireForTransport(ctx context.Context, requestID string, appendSeq int64, allowRestart bool) (appendSequenceTicket, bool, error) {
+	return tracker.acquireForTransport(ctx, requestID, appendSeq, allowRestart, nil)
+}
+
+func (tracker *appendSequenceTracker) AcquireForTransportWithFingerprint(ctx context.Context, requestID string, appendSeq int64, allowRestart bool, fingerprint [32]byte) (appendSequenceTicket, bool, error) {
+	return tracker.acquireForTransport(ctx, requestID, appendSeq, allowRestart, &fingerprint)
+}
+
+func (tracker *appendSequenceTracker) acquireForTransport(ctx context.Context, requestID string, appendSeq int64, allowRestart bool, fingerprint *[32]byte) (appendSequenceTicket, bool, error) {
+	if tracker == nil || strings.TrimSpace(requestID) == "" {
+		return appendSequenceTicket{}, false, nil
+	}
+	if appendSeq < 0 {
 		return appendSequenceTicket{}, false, nil
 	}
 	requestID = strings.TrimSpace(requestID)
+	return tracker.acquireStateWithFingerprint(ctx, requestID, appendSeq, allowRestart, fingerprint)
+}
+
+func (tracker *appendSequenceTracker) acquireState(ctx context.Context, requestID string, appendSeq int64, allowRestart bool) (appendSequenceTicket, bool, error) {
+	return tracker.acquireStateWithFingerprint(ctx, requestID, appendSeq, allowRestart, nil)
+}
+
+func (tracker *appendSequenceTracker) acquireStateWithFingerprint(ctx context.Context, requestID string, appendSeq int64, allowRestart bool, fingerprint *[32]byte) (appendSequenceTicket, bool, error) {
+	if tracker == nil || requestID == "" {
+		return appendSequenceTicket{}, false, nil
+	}
 	state := tracker.state(requestID)
-	stale, err := state.acquire(ctx, requestID, appendSeq)
+	stale, generation, replayRestarted, err := state.acquire(ctx, requestID, appendSeq, allowRestart, fingerprint)
 	if err != nil || stale {
 		return appendSequenceTicket{}, stale, err
 	}
 	return appendSequenceTicket{
-		state: state,
-		seq:   appendSeq,
+		state:           state,
+		seq:             appendSeq,
+		generation:      generation,
+		replayRestarted: replayRestarted,
 	}, false, nil
 }
 
@@ -66,7 +138,7 @@ func (tracker *appendSequenceTracker) state(requestID string) *appendSequenceSta
 		return state
 	}
 	state := &appendSequenceState{
-		next:      1,
+		next:      0,
 		ready:     make(chan struct{}),
 		updatedAt: now,
 	}
@@ -74,75 +146,504 @@ func (tracker *appendSequenceTracker) state(requestID string) *appendSequenceSta
 	return state
 }
 
-func (state *appendSequenceState) acquire(ctx context.Context, requestID string, appendSeq int64) (bool, error) {
+// IsDefinitelyStale is a non-blocking filter for early control signals.
+func (tracker *appendSequenceTracker) IsDefinitelyStale(requestID string, appendSeq int64, allowRestart bool) bool {
+	if tracker == nil || strings.TrimSpace(requestID) == "" || appendSeq < 0 {
+		return false
+	}
+	requestID = strings.TrimSpace(requestID)
+	tracker.mu.Lock()
+	state := tracker.states[requestID]
+	tracker.mu.Unlock()
+	if state == nil {
+		return false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.canRestartLocked(appendSeq, allowRestart) {
+		return false
+	}
+	return appendSeq < state.next
+}
+
+func (tracker *appendSequenceTracker) ObserveSequenceZeroFingerprint(requestID string, fingerprint [32]byte) bool {
+	if tracker == nil || strings.TrimSpace(requestID) == "" {
+		return true
+	}
+	requestID = strings.TrimSpace(requestID)
+	state := tracker.state(requestID)
+	now := time.Now().UTC()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	currentFingerprint, exists := state.acceptedFingerprints[0]
+	if exists && currentFingerprint == fingerprint {
+		if !state.sequenceZeroReplayPendingLocked() {
+			state.beginSequenceZeroReplayLocked()
+		}
+		state.sequenceZeroReplayPending = true
+		state.sequenceZeroReplayGeneration = state.restartGeneration
+		state.updatedAt = now
+		return false
+	}
+	return true
+}
+
+func (tracker *appendSequenceTracker) ReplayRestartCandidate(requestID string, appendSeq int64, fingerprint [32]byte) (appendSequenceGeneration, bool) {
+	requestID = strings.TrimSpace(requestID)
+	if tracker == nil || requestID == "" || appendSeq <= 0 {
+		return appendSequenceGeneration{}, false
+	}
+	tracker.mu.Lock()
+	state := tracker.states[requestID]
+	tracker.mu.Unlock()
+	if state == nil {
+		return appendSequenceGeneration{}, false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if !state.sequenceZeroReplayPendingLocked() || appendSeq >= state.sequenceZeroReplayBaseNext {
+		return appendSequenceGeneration{}, false
+	}
+	if state.fingerprintMatchesLocked(appendSeq, &fingerprint) {
+		return appendSequenceGeneration{}, false
+	}
+	state.sequenceZeroReplayChangeObserved = true
+	return state.generationLocked(), true
+}
+
+// CompleteAhead records a control-plane append without making its RPC wait
+// behind a long-running earlier append. Once the gap closes, Release advances
+// across these completed sequence numbers before waking ordered waiters.
+func (tracker *appendSequenceTracker) CompleteAhead(requestID string, appendSeq int64) bool {
+	requestID = strings.TrimSpace(requestID)
+	if tracker == nil || requestID == "" || appendSeq <= 0 {
+		return false
+	}
+	return tracker.state(requestID).completeAhead(appendSeq, nil).stale
+}
+
+func (tracker *appendSequenceTracker) CaptureGeneration(requestID string) appendSequenceGeneration {
+	requestID = strings.TrimSpace(requestID)
+	if tracker == nil || requestID == "" {
+		return appendSequenceGeneration{}
+	}
+	state := tracker.state(requestID)
+	state.mu.Lock()
+	generation := appendSequenceGeneration{
+		state:             state,
+		restartGeneration: state.restartGeneration,
+	}
+	state.mu.Unlock()
+	return generation
+}
+
+func (tracker *appendSequenceTracker) CompleteAheadForGeneration(requestID string, appendSeq int64, generation appendSequenceGeneration) (bool, bool) {
+	matched, completion := tracker.CompleteAheadForGenerationWithFingerprint(requestID, appendSeq, generation, nil)
+	return matched, completion.stale
+}
+
+func (tracker *appendSequenceTracker) CompleteAheadForGenerationWithFingerprint(requestID string, appendSeq int64, generation appendSequenceGeneration, fingerprint *[32]byte) (bool, appendSequenceCompletion) {
+	requestID = strings.TrimSpace(requestID)
+	if tracker == nil || requestID == "" || appendSeq <= 0 || generation.state == nil {
+		return false, appendSequenceCompletion{}
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	state := tracker.states[requestID]
+	if state == nil || state != generation.state {
+		return false, appendSequenceCompletion{}
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.restartGeneration != generation.restartGeneration {
+		return false, appendSequenceCompletion{}
+	}
+	return true, state.completeAheadLocked(appendSeq, fingerprint)
+}
+
+func (state *appendSequenceState) completeAhead(appendSeq int64, fingerprint *[32]byte) appendSequenceCompletion {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.completeAheadLocked(appendSeq, fingerprint)
+}
+
+func (state *appendSequenceState) completeAheadLocked(appendSeq int64, fingerprint *[32]byte) appendSequenceCompletion {
+	state.updatedAt = time.Now().UTC()
+	completion := appendSequenceCompletion{generation: state.generationLocked()}
+	if state.sequenceZeroReplayPendingLocked() && appendSeq > 0 {
+		baseNext := state.sequenceZeroReplayBaseNext
+		switch {
+		case appendSeq < baseNext && state.fingerprintMatchesLocked(appendSeq, fingerprint):
+			state.rememberReplayDuplicateLocked(appendSeq, fingerprint)
+			state.notifyReadyLocked()
+			completion.stale = true
+			return completion
+		case appendSeq < baseNext && !state.replayPrefixConfirmedLocked(appendSeq):
+			state.sequenceZeroReplayChangeObserved = true
+			completion.retry = true
+			return completion
+		case appendSeq < baseNext:
+			state.sequenceZeroReplayChangeObserved = true
+			completion.generation = state.resetForSequenceZeroReplayLocked(appendSeq)
+			completion.replayRestarted = true
+		case appendSeq == state.next && !state.processing && state.next >= baseNext:
+			if state.sequenceZeroReplayChangeObserved {
+				completion.retry = true
+				return completion
+			}
+			state.clearSequenceZeroReplayLocked()
+		}
+	}
+	if state.consumeReplayBaselineLocked(appendSeq, fingerprint) {
+		completion.stale = true
+		completion.generation = state.generationLocked()
+		return completion
+	}
+	if appendSeq < state.next || (appendSeq == state.next && state.processing) {
+		completion.stale = true
+		completion.generation = state.generationLocked()
+		return completion
+	}
+	if state.completed == nil {
+		state.completed = make(map[int64]struct{})
+	}
+	if _, exists := state.completed[appendSeq]; exists {
+		completion.stale = true
+		completion.generation = state.generationLocked()
+		return completion
+	}
+	state.completed[appendSeq] = struct{}{}
+	state.rememberAcceptedFingerprintLocked(appendSeq, fingerprint)
+	if !state.processing && appendSeq == state.next {
+		state.advanceCompletedLocked()
+		state.notifyReadyLocked()
+	}
+	completion.generation = state.generationLocked()
+	return completion
+}
+
+func (state *appendSequenceState) acquire(ctx context.Context, requestID string, appendSeq int64, allowRestart bool, fingerprint *[32]byte) (bool, appendSequenceGeneration, bool, error) {
+	restartDecisionMade := false
+	restartEligible := false
+	var observedRestartGeneration uint64
 	for {
 		state.mu.Lock()
 		now := time.Now().UTC()
-		if state.next <= 0 {
-			state.next = 1
+		if state.next < 0 {
+			state.next = 0
 		}
 		if state.ready == nil {
 			state.ready = make(chan struct{})
 		}
 		state.updatedAt = now
+		if fingerprint != nil && appendSeq == 0 {
+			if state.fingerprintMatchesLocked(0, fingerprint) {
+				if !state.sequenceZeroReplayPendingLocked() {
+					state.beginSequenceZeroReplayLocked()
+				}
+				state.sequenceZeroReplayPending = true
+				state.sequenceZeroReplayGeneration = state.restartGeneration
+				state.mu.Unlock()
+				return true, appendSequenceGeneration{}, false, nil
+			}
+		}
 
-		// Cursor may reuse the same request_id for a later turn and restart
-		// append_seqno from 1. Accept that as a sequence restart when idle so
-		// tool results are not discarded as stale forever.
-		if appendSeq == 1 && state.next > 1 {
+		// A new Bidi transport restarts at seqno 0 only after the caller has
+		// validated the active stream or pending-operation lifecycle.
+		if !restartDecisionMade {
+			restartEligible = state.canRestartLocked(appendSeq, allowRestart)
+			observedRestartGeneration = state.restartGeneration
+			restartDecisionMade = true
+		}
+		// Another seqno 0 waiter already claimed this lifecycle. Permanently
+		// revoke this waiter's restart eligibility so it becomes stale after
+		// the winner releases instead of resetting the sequence a second time.
+		if restartEligible && state.restartGeneration != observedRestartGeneration {
+			restartEligible = false
+		}
+		if restartEligible {
 			if state.processing {
 				ready := state.ready
 				state.mu.Unlock()
 				select {
 				case <-ctx.Done():
-					return false, ctx.Err()
+					return false, appendSequenceGeneration{}, false, ctx.Err()
 				case <-ready:
 				}
 				continue
 			}
 			prevNext := state.next
-			state.next = 1
+			state.next = 0
 			state.processing = true
+			state.completed = nil
+			state.restartGeneration = nextAppendSequenceRestartGeneration(state.restartGeneration)
+			state.clearSequenceZeroReplayLocked()
+			state.clearReplayBaselineLocked()
+			state.acceptedFingerprints = nil
+			state.rememberAcceptedFingerprintLocked(appendSeq, fingerprint)
+			generation := state.generationLocked()
 			state.mu.Unlock()
-			log.Printf("forwarder reset append sequence request_id=%s previous_next=%d append_seqno=1", requestID, prevNext)
-			return false, nil
+			log.Printf("forwarder reset append sequence request_id=%s previous_next=%d append_seqno=0", requestID, prevNext)
+			return false, generation, false, nil
+		}
+		if state.sequenceZeroReplayPendingLocked() && appendSeq > 0 {
+			baseNext := state.sequenceZeroReplayBaseNext
+			switch {
+			case appendSeq < baseNext && state.fingerprintMatchesLocked(appendSeq, fingerprint):
+				state.rememberReplayDuplicateLocked(appendSeq, fingerprint)
+				state.notifyReadyLocked()
+				state.mu.Unlock()
+				return true, appendSequenceGeneration{}, false, nil
+			case appendSeq < baseNext:
+				state.sequenceZeroReplayChangeObserved = true
+				if state.processing || !state.replayPrefixConfirmedLocked(appendSeq) {
+					ready := state.ready
+					state.mu.Unlock()
+					select {
+					case <-ctx.Done():
+						return false, appendSequenceGeneration{}, false, ctx.Err()
+					case <-ready:
+					}
+					continue
+				}
+				prevNext := state.next
+				generation := state.resetForSequenceZeroReplayLocked(appendSeq)
+				state.processing = true
+				state.rememberAcceptedFingerprintLocked(appendSeq, fingerprint)
+				state.mu.Unlock()
+				log.Printf("forwarder confirmed append sequence replay request_id=%s previous_next=%d append_seqno=%d", requestID, prevNext, appendSeq)
+				return false, generation, true, nil
+			case appendSeq == state.next && !state.processing && state.next >= baseNext:
+				if state.sequenceZeroReplayChangeObserved {
+					ready := state.ready
+					state.mu.Unlock()
+					select {
+					case <-ctx.Done():
+						return false, appendSequenceGeneration{}, false, ctx.Err()
+					case <-ready:
+					}
+					continue
+				}
+				state.clearSequenceZeroReplayLocked()
+			}
+		}
+		if state.consumeReplayBaselineLocked(appendSeq, fingerprint) {
+			generation := state.generationLocked()
+			state.mu.Unlock()
+			return true, generation, false, nil
 		}
 
 		switch {
 		case appendSeq < state.next:
 			state.mu.Unlock()
-			return true, nil
+			return true, appendSequenceGeneration{}, false, nil
 		case appendSeq == state.next && !state.processing:
 			state.processing = true
+			if appendSeq == 0 && fingerprint != nil {
+				state.clearSequenceZeroReplayLocked()
+				state.clearReplayBaselineLocked()
+				state.acceptedFingerprints = nil
+			}
+			state.rememberAcceptedFingerprintLocked(appendSeq, fingerprint)
+			generation := state.generationLocked()
 			state.mu.Unlock()
-			return false, nil
+			return false, generation, false, nil
 		default:
 			ready := state.ready
 			state.mu.Unlock()
 			select {
 			case <-ctx.Done():
-				return false, ctx.Err()
+				return false, appendSequenceGeneration{}, false, ctx.Err()
 			case <-ready:
 			}
 		}
 	}
 }
 
-func (state *appendSequenceState) Release(seq int64) {
-	if state == nil || seq <= 0 {
+func nextAppendSequenceRestartGeneration(current uint64) uint64 {
+	next := current + 1
+	if next == 0 {
+		next++
+	}
+	return next
+}
+
+func (state *appendSequenceState) canRestartLocked(appendSeq int64, allowRestart bool) bool {
+	return state != nil && allowRestart && appendSeq == 0 && (state.next > 0 || state.processing)
+}
+
+func (state *appendSequenceState) Release(seq int64, generation appendSequenceGeneration) {
+	if state == nil || seq < 0 || generation.state != state {
 		return
 	}
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
+	if state.restartGeneration != generation.restartGeneration {
+		return
+	}
 	if state.processing && state.next == seq {
 		state.processing = false
 		state.next++
-		close(state.ready)
-		state.ready = make(chan struct{})
+		state.advanceCompletedLocked()
+		state.notifyReadyLocked()
 	}
 	state.updatedAt = time.Now().UTC()
+}
+
+func (state *appendSequenceState) resetForSequenceZeroReplayLocked(appendSeq int64) appendSequenceGeneration {
+	previousFingerprints := state.acceptedFingerprints
+	baseNext := state.sequenceZeroReplayBaseNext
+	replayDuplicates := state.replayDuplicateFingerprints
+
+	state.next = appendSeq
+	state.processing = false
+	state.completed = make(map[int64]struct{})
+	state.restartGeneration = nextAppendSequenceRestartGeneration(state.restartGeneration)
+	state.acceptedFingerprints = make(map[int64][32]byte)
+	if fingerprint, ok := previousFingerprints[0]; ok {
+		state.acceptedFingerprints[0] = fingerprint
+	}
+	for seq, fingerprint := range replayDuplicates {
+		state.acceptedFingerprints[seq] = fingerprint
+		if seq >= appendSeq {
+			state.completed[seq] = struct{}{}
+		}
+	}
+	state.replayBaselineFingerprints = previousFingerprints
+	state.replayBaselineExclusiveSequence = baseNext
+	state.clearSequenceZeroReplayLocked()
+	state.notifyReadyLocked()
+	return state.generationLocked()
+}
+
+func (state *appendSequenceState) sequenceZeroReplayPendingLocked() bool {
+	if !state.sequenceZeroReplayPending {
+		return false
+	}
+	if state.sequenceZeroReplayGeneration == state.restartGeneration {
+		return true
+	}
+	state.clearSequenceZeroReplayLocked()
+	return false
+}
+
+func (state *appendSequenceState) beginSequenceZeroReplayLocked() {
+	state.replayDuplicateFingerprints = nil
+	state.sequenceZeroReplayChangeObserved = false
+	state.sequenceZeroReplayBaseNext = state.next
+	if state.processing && state.sequenceZeroReplayBaseNext < maxAppendSequence {
+		state.sequenceZeroReplayBaseNext++
+	}
+}
+
+func (state *appendSequenceState) clearSequenceZeroReplayLocked() {
+	state.sequenceZeroReplayPending = false
+	state.sequenceZeroReplayGeneration = 0
+	state.sequenceZeroReplayBaseNext = 0
+	state.sequenceZeroReplayChangeObserved = false
+	state.replayDuplicateFingerprints = nil
+}
+
+func (state *appendSequenceState) clearReplayBaselineLocked() {
+	state.replayBaselineFingerprints = nil
+	state.replayBaselineExclusiveSequence = 0
+}
+
+func (state *appendSequenceState) generationLocked() appendSequenceGeneration {
+	return appendSequenceGeneration{
+		state:             state,
+		restartGeneration: state.restartGeneration,
+	}
+}
+
+func (state *appendSequenceState) fingerprintMatchesLocked(appendSeq int64, fingerprint *[32]byte) bool {
+	if state == nil || fingerprint == nil {
+		return false
+	}
+	expected, ok := state.acceptedFingerprints[appendSeq]
+	return ok && expected == *fingerprint
+}
+
+func (state *appendSequenceState) rememberAcceptedFingerprintLocked(appendSeq int64, fingerprint *[32]byte) {
+	if state == nil || appendSeq < 0 || fingerprint == nil {
+		return
+	}
+	if state.acceptedFingerprints == nil {
+		state.acceptedFingerprints = make(map[int64][32]byte)
+	}
+	state.acceptedFingerprints[appendSeq] = *fingerprint
+}
+
+func (state *appendSequenceState) rememberReplayDuplicateLocked(appendSeq int64, fingerprint *[32]byte) {
+	if state == nil || appendSeq <= 0 || fingerprint == nil {
+		return
+	}
+	if state.replayDuplicateFingerprints == nil {
+		state.replayDuplicateFingerprints = make(map[int64][32]byte)
+	}
+	state.replayDuplicateFingerprints[appendSeq] = *fingerprint
+}
+
+func (state *appendSequenceState) replayPrefixConfirmedLocked(appendSeq int64) bool {
+	if state == nil || appendSeq <= 1 {
+		return true
+	}
+	for seq := int64(1); seq < appendSeq; seq++ {
+		if _, ok := state.replayDuplicateFingerprints[seq]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (state *appendSequenceState) consumeReplayBaselineLocked(appendSeq int64, fingerprint *[32]byte) bool {
+	if state == nil || fingerprint == nil || appendSeq <= 0 || appendSeq >= state.replayBaselineExclusiveSequence {
+		return false
+	}
+	expected, ok := state.replayBaselineFingerprints[appendSeq]
+	if !ok || expected != *fingerprint {
+		return false
+	}
+	state.rememberAcceptedFingerprintLocked(appendSeq, fingerprint)
+	if appendSeq < state.next {
+		return true
+	}
+	if state.completed == nil {
+		state.completed = make(map[int64]struct{})
+	}
+	state.completed[appendSeq] = struct{}{}
+	if !state.processing && appendSeq == state.next {
+		state.advanceCompletedLocked()
+		state.notifyReadyLocked()
+	}
+	return true
+}
+
+func (state *appendSequenceState) advanceCompletedLocked() {
+	for {
+		_, ok := state.completed[state.next]
+		if !ok {
+			break
+		}
+		delete(state.completed, state.next)
+		state.next++
+	}
+	if state.replayBaselineExclusiveSequence > 0 && state.next >= state.replayBaselineExclusiveSequence {
+		state.clearReplayBaselineLocked()
+	}
+	// Advancing can be caused by work accepted before a duplicate seqno 0.
+	// Only an explicit expected append can prove that no replay is in progress.
+}
+
+func (state *appendSequenceState) notifyReadyLocked() {
+	if state.ready == nil {
+		state.ready = make(chan struct{})
+		return
+	}
+	close(state.ready)
+	state.ready = make(chan struct{})
 }
 
 func (state *appendSequenceState) expired(cutoff time.Time) bool {
@@ -167,8 +668,32 @@ func (state *appendSequenceState) touch(now time.Time) {
 }
 
 func (ticket appendSequenceTicket) Release() {
-	if ticket.state == nil || ticket.seq <= 0 {
+	if ticket.state == nil || ticket.seq < 0 {
 		return
 	}
-	ticket.state.Release(ticket.seq)
+	ticket.state.Release(ticket.seq, ticket.generation)
+}
+
+func (ticket appendSequenceTicket) CompleteAhead(appendSeq int64) {
+	ticket.CompleteAheadWithFingerprint(appendSeq, nil)
+}
+
+func (ticket appendSequenceTicket) CompleteAheadWithFingerprint(appendSeq int64, fingerprint *[32]byte) appendSequenceCompletion {
+	if ticket.state == nil || ticket.seq != 0 || appendSeq <= 0 {
+		return appendSequenceCompletion{}
+	}
+	ticket.state.mu.Lock()
+	defer ticket.state.mu.Unlock()
+	if ticket.state.restartGeneration != ticket.generation.restartGeneration {
+		return appendSequenceCompletion{retry: true}
+	}
+	return ticket.state.completeAheadLocked(appendSeq, fingerprint)
+}
+
+func (ticket appendSequenceTicket) Generation() appendSequenceGeneration {
+	return ticket.generation
+}
+
+func (ticket appendSequenceTicket) ReplayRestarted() bool {
+	return ticket.replayRestarted
 }

--- a/internal/backend/forwarder/blob_store.go
+++ b/internal/backend/forwarder/blob_store.go
@@ -1,0 +1,1771 @@
+package forwarder
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"cursor/gen/agentv1"
+)
+
+const (
+	conversationBlobDirectoryName   = ".blobs"
+	conversationBlobMaxItemBytes    = 64 << 20
+	conversationBlobMaxRequestBytes = 256 << 20
+	conversationBlobMaxRequestItems = 1000
+	conversationPrefetchMaxBytes    = 32 << 20
+	conversationPrefetchMaxItems    = 512
+	conversationBidiMaxRequestBytes = (conversationBlobMaxItemBytes * 2) + (16 << 20)
+	conversationBlobMaxStoreBytes   = int64(4 << 30)
+	conversationBlobGCGracePeriod   = 7 * 24 * time.Hour
+	conversationBlobAckTimeout      = 10 * time.Second
+	conversationBlobAckBatchTimeout = 30 * time.Second
+	conversationBlobImportIdleTime  = 10 * time.Second
+	conversationBlobImportPoll      = 250 * time.Millisecond
+	conversationBlobGetMaxInFlight  = 128
+	conversationBlobRetryBase       = time.Second
+	conversationBlobRetryMax        = 30 * time.Second
+	completedKVAckRetention         = 10 * time.Minute
+)
+
+var (
+	errConversationBlobStoreFull = errors.New("conversation blob store is full")
+	errConversationBlobCorrupt   = errors.New("conversation blob is corrupt")
+)
+
+type ConversationBlobStore struct {
+	mu        sync.RWMutex
+	root      string
+	memory    map[[sha256.Size]byte][]byte
+	verified  map[[sha256.Size]byte]struct{}
+	totalSize int64
+	sizeKnown bool
+}
+
+func NewConversationBlobStore(historyRoot string) *ConversationBlobStore {
+	root := ""
+	if strings.TrimSpace(historyRoot) != "" {
+		root = filepath.Join(strings.TrimSpace(historyRoot), conversationBlobDirectoryName)
+	}
+	return &ConversationBlobStore{
+		root:     root,
+		memory:   make(map[[sha256.Size]byte][]byte),
+		verified: make(map[[sha256.Size]byte]struct{}),
+	}
+}
+
+func (store *ConversationBlobStore) Put(id []byte, data []byte) error {
+	return store.put(id, data)
+}
+
+// PutProjected persists a blob produced from trusted local history. Digests
+// already verified by this process need no repeated full-file validation.
+func (store *ConversationBlobStore) PutProjected(id []byte, data []byte) error {
+	digest, err := parseBlobDigest(id)
+	if err != nil {
+		return err
+	}
+	if len(data) > conversationBlobMaxItemBytes {
+		return fmt.Errorf("conversation blob exceeds %d byte limit", conversationBlobMaxItemBytes)
+	}
+	store.mu.RLock()
+	_, verified := store.verified[digest]
+	store.mu.RUnlock()
+	if verified {
+		return nil
+	}
+	return store.put(id, data)
+}
+
+func (store *ConversationBlobStore) put(id []byte, data []byte) error {
+	digest, err := validatedBlobDigest(id, data)
+	if err != nil {
+		return err
+	}
+	if len(data) > conversationBlobMaxItemBytes {
+		return fmt.Errorf("conversation blob exceeds %d byte limit", conversationBlobMaxItemBytes)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.root == "" {
+		if existing, ok := store.memory[digest]; ok {
+			if !bytes.Equal(existing, data) {
+				return fmt.Errorf("conversation blob collision for %s", hex.EncodeToString(digest[:]))
+			}
+			store.verified[digest] = struct{}{}
+			return nil
+		}
+		if store.totalSize+int64(len(data)) > conversationBlobMaxStoreBytes {
+			return fmt.Errorf("%w: exceeds %d byte limit", errConversationBlobStoreFull, conversationBlobMaxStoreBytes)
+		}
+		store.memory[digest] = append([]byte(nil), data...)
+		store.verified[digest] = struct{}{}
+		store.totalSize += int64(len(data))
+		store.sizeKnown = true
+		return nil
+	}
+	if err := os.MkdirAll(store.root, 0o755); err != nil {
+		return fmt.Errorf("create conversation blob directory: %w", err)
+	}
+	path := filepath.Join(store.root, hex.EncodeToString(digest[:]))
+	if info, err := os.Stat(path); err == nil {
+		existing, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("read conversation blob: %w", readErr)
+		}
+		if _, validationErr := validatedBlobDigest(id, existing); validationErr == nil {
+			if !bytes.Equal(existing, data) {
+				return fmt.Errorf("conversation blob collision for %s", hex.EncodeToString(digest[:]))
+			}
+			now := time.Now()
+			if err := os.Chtimes(path, now, now); err != nil {
+				return fmt.Errorf("refresh conversation blob lease: %w", err)
+			}
+			store.verified[digest] = struct{}{}
+			return nil
+		}
+		if err := store.loadSizeLocked(); err != nil {
+			return err
+		}
+		replacementSize := store.totalSize - info.Size() + int64(len(data))
+		if replacementSize > conversationBlobMaxStoreBytes {
+			return fmt.Errorf("%w: exceeds %d byte limit", errConversationBlobStoreFull, conversationBlobMaxStoreBytes)
+		}
+		if err := writeConversationBlobFile(store.root, path, data, true); err != nil {
+			return err
+		}
+		store.totalSize = replacementSize
+		store.verified[digest] = struct{}{}
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read conversation blob: %w", err)
+	}
+	if err := store.loadSizeLocked(); err != nil {
+		return err
+	}
+	if store.totalSize+int64(len(data)) > conversationBlobMaxStoreBytes {
+		return fmt.Errorf("%w: exceeds %d byte limit", errConversationBlobStoreFull, conversationBlobMaxStoreBytes)
+	}
+	if err := writeConversationBlobFile(store.root, path, data, false); err != nil {
+		return err
+	}
+	store.totalSize += int64(len(data))
+	store.verified[digest] = struct{}{}
+	return nil
+}
+
+func writeConversationBlobFile(root string, path string, data []byte, replace bool) error {
+	temporary, err := os.CreateTemp(root, ".blob-*")
+	if err != nil {
+		return fmt.Errorf("create temporary conversation blob: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("write temporary conversation blob: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary conversation blob: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		if !replace {
+			return fmt.Errorf("commit conversation blob: %w", err)
+		}
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return fmt.Errorf("replace corrupt conversation blob: %w", removeErr)
+		}
+		if retryErr := os.Rename(temporaryPath, path); retryErr != nil {
+			return fmt.Errorf("commit repaired conversation blob: %w", retryErr)
+		}
+	}
+	removeTemporary = false
+	return nil
+}
+
+func (store *ConversationBlobStore) Get(id []byte) ([]byte, error) {
+	digest, err := parseBlobDigest(id)
+	if err != nil {
+		return nil, err
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.root == "" {
+		data, ok := store.memory[digest]
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return append([]byte(nil), data...), nil
+	}
+	data, err := os.ReadFile(filepath.Join(store.root, hex.EncodeToString(digest[:])))
+	if err != nil {
+		delete(store.verified, digest)
+		return nil, err
+	}
+	if _, err := validatedBlobDigest(id, data); err != nil {
+		delete(store.verified, digest)
+		return nil, fmt.Errorf("%w: %v", errConversationBlobCorrupt, err)
+	}
+	store.verified[digest] = struct{}{}
+	return data, nil
+}
+
+func (store *ConversationBlobStore) Prune(reachable map[[sha256.Size]byte]struct{}, cutoff time.Time) error {
+	if store == nil || store.root == "" {
+		return nil
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	entries, err := os.ReadDir(store.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			store.totalSize = 0
+			store.sizeKnown = true
+			return nil
+		}
+		return fmt.Errorf("scan conversation blob directory: %w", err)
+	}
+	var totalSize int64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(store.root, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("read conversation blob info: %w", err)
+		}
+		if strings.HasPrefix(entry.Name(), ".blob-") {
+			if info.ModTime().Before(cutoff) {
+				if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("remove stale temporary conversation blob: %w", err)
+				}
+				continue
+			}
+			totalSize += info.Size()
+			continue
+		}
+		digest, ok := parseBlobFileName(entry.Name())
+		if !ok {
+			totalSize += info.Size()
+			continue
+		}
+		if _, keep := reachable[digest]; !keep && info.ModTime().Before(cutoff) {
+			if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove unreachable conversation blob: %w", err)
+			}
+			delete(store.verified, digest)
+			continue
+		}
+		totalSize += info.Size()
+	}
+	store.totalSize = totalSize
+	store.sizeKnown = true
+	return nil
+}
+
+func (store *ConversationBlobStore) loadSizeLocked() error {
+	if store.sizeKnown || store.root == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(store.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			store.sizeKnown = true
+			return nil
+		}
+		return fmt.Errorf("scan conversation blob directory: %w", err)
+	}
+	var totalSize int64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("read conversation blob info: %w", err)
+		}
+		totalSize += info.Size()
+	}
+	store.totalSize = totalSize
+	store.sizeKnown = true
+	return nil
+}
+
+func parseBlobFileName(name string) ([sha256.Size]byte, bool) {
+	var digest [sha256.Size]byte
+	if len(name) != sha256.Size*2 {
+		return digest, false
+	}
+	decoded, err := hex.DecodeString(name)
+	if err != nil || len(decoded) != sha256.Size {
+		return digest, false
+	}
+	copy(digest[:], decoded)
+	return digest, true
+}
+
+func parseBlobDigest(id []byte) ([sha256.Size]byte, error) {
+	var digest [sha256.Size]byte
+	if len(id) != sha256.Size {
+		return digest, fmt.Errorf("blob id must contain %d bytes", sha256.Size)
+	}
+	copy(digest[:], id)
+	return digest, nil
+}
+
+func validatedBlobDigest(id []byte, data []byte) ([sha256.Size]byte, error) {
+	digest, err := parseBlobDigest(id)
+	if err != nil {
+		return digest, err
+	}
+	computed := sha256.Sum256(data)
+	if computed != digest {
+		return digest, fmt.Errorf("blob id does not match SHA-256 content digest")
+	}
+	return digest, nil
+}
+
+func (service *Service) UploadConversationBlobs(_ context.Context, req *connect.Request[agentv1.UploadConversationBlobsRequest]) (*connect.Response[agentv1.UploadConversationBlobsResponse], error) {
+	if service == nil || service.blobStore == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("conversation blob store is not available"))
+	}
+	if req == nil || req.Msg == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("request payload is required"))
+	}
+	if _, err := validateConversationID(req.Msg.GetConversationId()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := validateUploadChunk(req.Msg.GetChunkIndex(), req.Msg.GetTotalChunks()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := validateBlobBatch(req.Msg.GetBlobs()); err != nil {
+		return nil, connect.NewError(connect.CodeResourceExhausted, err)
+	}
+	for index, blob := range req.Msg.GetBlobs() {
+		if blob == nil {
+			continue
+		}
+		if err := service.putConversationBlobWithRecovery(blob.GetId(), blob.GetValue()); err != nil {
+			code := connect.CodeInvalidArgument
+			if errors.Is(err, errConversationBlobStoreFull) {
+				code = connect.CodeResourceExhausted
+			}
+			return nil, connect.NewError(code, fmt.Errorf("store uploaded conversation blob %d: %w", index, err))
+		}
+	}
+	return connect.NewResponse(&agentv1.UploadConversationBlobsResponse{}), nil
+}
+
+func (service *Service) NotifyConversationClone(ctx context.Context, req *connect.Request[agentv1.NotifyConversationCloneRequest]) (*connect.Response[agentv1.NotifyConversationCloneResponse], error) {
+	if req == nil || req.Msg == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("request payload is required"))
+	}
+	destinationID, err := validateConversationID(req.Msg.GetConversationId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	sourceID, err := validateConversationID(req.Msg.GetSourceConversationId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if destinationID == sourceID {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("clone destination must differ from source conversation"))
+	}
+	if service == nil || service.store == nil || service.projector == nil || service.blobStore == nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("conversation clone projection is not available"))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, connect.NewError(connect.CodeCanceled, err)
+	}
+	source, err := service.store.LoadConversation(sourceID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("load clone source conversation: %w", err))
+	}
+	if source == nil {
+		return connect.NewResponse(&agentv1.NotifyConversationCloneResponse{}), nil
+	}
+	projection, err := service.projector.ProjectLegacyCheckpointWithBlobs(source)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("project clone source conversation: %w", err))
+	}
+	if err := service.persistCheckpointBlobs(projection.Blobs); err != nil {
+		code := connect.CodeInternal
+		if errors.Is(err, errConversationBlobStoreFull) {
+			code = connect.CodeResourceExhausted
+		}
+		return nil, connect.NewError(code, fmt.Errorf("persist clone source blobs: %w", err))
+	}
+	return connect.NewResponse(&agentv1.NotifyConversationCloneResponse{}), nil
+}
+
+func validateUploadChunk(chunkIndex int32, totalChunks int32) error {
+	if chunkIndex < 0 || totalChunks < 0 {
+		return fmt.Errorf("upload chunk indexes must be non-negative")
+	}
+	if totalChunks == 0 {
+		if chunkIndex != 0 {
+			return fmt.Errorf("chunk_index must be zero when total_chunks is zero")
+		}
+		return nil
+	}
+	if chunkIndex >= totalChunks {
+		return fmt.Errorf("chunk_index must be less than total_chunks")
+	}
+	return nil
+}
+
+func validateBlobBatch(blobs []*agentv1.BlobEntry) error {
+	if len(blobs) > conversationBlobMaxRequestItems {
+		return fmt.Errorf("conversation blob upload exceeds %d item limit", conversationBlobMaxRequestItems)
+	}
+	var totalBytes int64
+	for _, blob := range blobs {
+		if blob == nil {
+			continue
+		}
+		if len(blob.GetValue()) > conversationBlobMaxItemBytes {
+			return fmt.Errorf("conversation blob exceeds %d byte limit", conversationBlobMaxItemBytes)
+		}
+		totalBytes += int64(len(blob.GetValue()))
+		if totalBytes > conversationBlobMaxRequestBytes {
+			return fmt.Errorf("conversation blob upload exceeds %d byte limit", conversationBlobMaxRequestBytes)
+		}
+	}
+	return nil
+}
+
+func (service *Service) persistPreFetchedBlobs(blobs []*agentv1.PreFetchedBlob) error {
+	if len(blobs) == 0 {
+		return nil
+	}
+	if service == nil || service.blobStore == nil {
+		return fmt.Errorf("conversation blob store is not available")
+	}
+	if len(blobs) > conversationPrefetchMaxItems {
+		return fmt.Errorf("pre-fetched blobs exceed %d item limit", conversationPrefetchMaxItems)
+	}
+	var totalBytes int64
+	for index, blob := range blobs {
+		if blob == nil {
+			continue
+		}
+		totalBytes += int64(len(blob.GetValue()))
+		if len(blob.GetValue()) > conversationBlobMaxItemBytes || totalBytes > conversationPrefetchMaxBytes {
+			return fmt.Errorf("pre-fetched blobs exceed capacity limit")
+		}
+		if err := service.putConversationBlobWithRecovery(blob.GetId(), blob.GetValue()); err != nil {
+			return fmt.Errorf("store pre-fetched conversation blob %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+func (service *Service) persistCheckpointBlobs(blobs []CheckpointBlob) error {
+	if len(blobs) == 0 {
+		return nil
+	}
+	if service == nil || service.blobStore == nil {
+		return fmt.Errorf("conversation blob store is not available")
+	}
+	for _, blob := range blobs {
+		if err := service.putProjectedConversationBlobWithRecovery(blob.ID, blob.Data); err != nil {
+			return fmt.Errorf("persist checkpoint blob: %w", err)
+		}
+	}
+	return nil
+}
+
+func (service *Service) putConversationBlobWithRecovery(id []byte, data []byte) error {
+	return service.putConversationBlobWithRecoveryMode(id, data, false)
+}
+
+func (service *Service) putProjectedConversationBlobWithRecovery(id []byte, data []byte) error {
+	return service.putConversationBlobWithRecoveryMode(id, data, true)
+}
+
+func (service *Service) putConversationBlobWithRecoveryMode(id []byte, data []byte, projected bool) error {
+	if service == nil || service.blobStore == nil {
+		return fmt.Errorf("conversation blob store is not available")
+	}
+	put := service.blobStore.Put
+	if projected {
+		put = service.blobStore.PutProjected
+	}
+	err := put(id, data)
+	if !errors.Is(err, errConversationBlobStoreFull) {
+		return err
+	}
+	if pruneErr := service.pruneConversationBlobs(); pruneErr != nil {
+		return fmt.Errorf("conversation blob store recovery failed: %v: %w", pruneErr, err)
+	}
+	return put(id, data)
+}
+
+func (service *Service) pruneConversationBlobs() error {
+	if service == nil || service.store == nil || service.blobStore == nil || service.projector == nil {
+		return nil
+	}
+	service.blobMaintenanceMu.Lock()
+	defer service.blobMaintenanceMu.Unlock()
+	conversationIDs, err := service.store.ListConversationIDs()
+	if err != nil {
+		return err
+	}
+	reachable := make(map[[sha256.Size]byte]struct{})
+	for _, conversationID := range conversationIDs {
+		conversation, err := service.store.LoadConversation(conversationID)
+		if err != nil {
+			return err
+		}
+		if conversation == nil {
+			continue
+		}
+		projection, err := service.projector.ProjectLegacyCheckpointWithBlobs(conversation)
+		if err != nil {
+			return fmt.Errorf("project conversation %s for blob pruning: %w", conversationID, err)
+		}
+		for _, blob := range projection.Blobs {
+			digest, err := parseBlobDigest(blob.ID)
+			if err != nil {
+				return err
+			}
+			reachable[digest] = struct{}{}
+		}
+	}
+	return service.blobStore.Prune(reachable, time.Now().UTC().Add(-conversationBlobGCGracePeriod))
+}
+
+type pendingBlobMessage struct {
+	ack  *pendingKVAck
+	blob CheckpointBlob
+}
+
+type checkpointBlobSendError struct {
+	err error
+}
+
+func (err *checkpointBlobSendError) Error() string {
+	if err == nil || err.err == nil {
+		return "send checkpoint blob"
+	}
+	return fmt.Sprintf("send checkpoint blob: %v", err.err)
+}
+
+func (err *checkpointBlobSendError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.err
+}
+
+func checkpointBlobIDs(blobs []CheckpointBlob) [][]byte {
+	if len(blobs) == 0 {
+		return nil
+	}
+	ids := make([][]byte, 0, len(blobs))
+	for _, blob := range blobs {
+		if len(blob.ID) == 0 {
+			continue
+		}
+		ids = append(ids, append([]byte(nil), blob.ID...))
+	}
+	return ids
+}
+
+func (service *Service) deliverCheckpointBlobs(
+	ctx context.Context,
+	deadline time.Time,
+	stream *ActiveStream,
+	blobIDs [][]byte,
+	delivered map[[sha256.Size]byte]struct{},
+	send func(*agentv1.AgentServerMessage) error,
+) (int, error) {
+	if !deadline.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(blobIDs) == 0 {
+		return 0, nil
+	}
+	if service == nil || service.blobStore == nil || service.broker == nil {
+		return 0, fmt.Errorf("conversation blob delivery is not available")
+	}
+	if send == nil {
+		return 0, fmt.Errorf("conversation blob sender is not available")
+	}
+	if stream == nil {
+		return 0, fmt.Errorf("request stream is not available")
+	}
+	blobs := make([]CheckpointBlob, 0, len(blobIDs))
+	seen := make(map[[sha256.Size]byte]struct{}, len(blobIDs))
+	for _, blobID := range blobIDs {
+		if err := ctx.Err(); err != nil {
+			return len(blobs), err
+		}
+		digest, err := parseBlobDigest(blobID)
+		if err != nil {
+			return len(blobs), err
+		}
+		if _, ok := delivered[digest]; ok {
+			continue
+		}
+		if _, ok := seen[digest]; ok {
+			continue
+		}
+		data, err := service.loadCheckpointBlob(stream, blobID)
+		if err != nil {
+			return len(blobs), fmt.Errorf("load checkpoint blob %s: %w", hex.EncodeToString(blobID), err)
+		}
+		seen[digest] = struct{}{}
+		blobs = append(blobs, CheckpointBlob{ID: append([]byte(nil), blobID...), Data: data})
+	}
+	if len(blobs) == 0 {
+		return 0, nil
+	}
+
+	pendingMessages := make([]pendingBlobMessage, 0, len(blobs))
+	stream.mu.Lock()
+	if stream.Status == StreamStatusCanceled || stream.Status == StreamStatusFailed {
+		stream.mu.Unlock()
+		return 0, fmt.Errorf("request is already terminal: %s", strings.TrimSpace(string(stream.Status)))
+	}
+	if stream.PendingKVAcks == nil {
+		stream.PendingKVAcks = make(map[uint32]*pendingKVAck)
+	}
+	for _, blob := range blobs {
+		digest, _ := parseBlobDigest(blob.ID)
+		pending := service.newPendingKVAckLocked(stream, digest, pendingKVOperationSetBlob, nil)
+		pendingMessages = append(pendingMessages, pendingBlobMessage{ack: pending, blob: blob})
+	}
+	stream.mu.Unlock()
+
+	for _, item := range pendingMessages {
+		if err := ctx.Err(); err != nil {
+			service.cancelKVAcks(stream, pendingMessages, err)
+			rememberDeliveredBlobAcks(pendingMessages, delivered)
+			return len(pendingMessages), err
+		}
+		if err := send(buildSetBlobMessage(item.ack.id, item.blob)); err != nil {
+			sendErr := &checkpointBlobSendError{err: err}
+			service.cancelKVAcks(stream, pendingMessages, sendErr)
+			rememberDeliveredBlobAcks(pendingMessages, delivered)
+			return len(pendingMessages), sendErr
+		}
+	}
+	acks := make([]*pendingKVAck, 0, len(pendingMessages))
+	for _, item := range pendingMessages {
+		acks = append(acks, item.ack)
+	}
+	if err := service.waitForKVAcks(ctx, acks); err != nil {
+		service.cancelKVAcks(stream, pendingMessages, err)
+		rememberDeliveredBlobAcks(pendingMessages, delivered)
+		return len(pendingMessages), err
+	}
+	rememberDeliveredBlobAcks(pendingMessages, delivered)
+	return len(pendingMessages), nil
+}
+
+func (service *Service) loadCheckpointBlob(stream *ActiveStream, blobID []byte) ([]byte, error) {
+	data, err := service.blobStore.Get(blobID)
+	if err == nil {
+		return data, nil
+	}
+	if stream == nil || service.projector == nil {
+		return nil, err
+	}
+	conversation, _, _, snapshotErr := service.snapshotCheckpointConversation(stream)
+	if snapshotErr != nil {
+		return nil, fmt.Errorf("repair checkpoint blob after %v: %w", err, snapshotErr)
+	}
+	projection, projectionErr := service.projector.ProjectLegacyCheckpointWithBlobs(conversation)
+	if projectionErr != nil {
+		return nil, fmt.Errorf("repair checkpoint blob after %v: %w", err, projectionErr)
+	}
+	for _, blob := range projection.Blobs {
+		if !bytes.Equal(blob.ID, blobID) {
+			continue
+		}
+		if putErr := service.putProjectedConversationBlobWithRecovery(blob.ID, blob.Data); putErr != nil {
+			return nil, fmt.Errorf("repair checkpoint blob after %v: %w", err, putErr)
+		}
+		return service.blobStore.Get(blobID)
+	}
+	return nil, err
+}
+
+func (service *Service) cancelKVAcks(stream *ActiveStream, messages []pendingBlobMessage, cause error) {
+	pending := make([]*pendingKVAck, 0, len(messages))
+	for _, item := range messages {
+		pending = append(pending, item.ack)
+	}
+	service.cancelPendingKVAcks(stream, pending, cause)
+}
+
+func (service *Service) cancelPendingKVAcks(stream *ActiveStream, pending []*pendingKVAck, cause error) {
+	if stream == nil {
+		for _, item := range pending {
+			item.complete(cause)
+		}
+		return
+	}
+	stream.mu.Lock()
+	for _, item := range pending {
+		if item == nil {
+			continue
+		}
+		if stream.PendingKVAcks[item.id] == item {
+			delete(stream.PendingKVAcks, item.id)
+		}
+		item.complete(cause)
+	}
+	stream.mu.Unlock()
+}
+
+func (service *Service) acknowledgeKVClientMessage(requestID string, message *agentv1.KvClientMessage) (appendSequenceGeneration, bool) {
+	if service == nil || message == nil {
+		return appendSequenceGeneration{}, false
+	}
+	route, ok := service.lookupKVAckRoute(requestID, message.GetId())
+	if !ok || !kvAckRouteMatchesMessage(route, message) {
+		return appendSequenceGeneration{}, false
+	}
+	if route.completed {
+		return route.appendGeneration, true
+	}
+	stream := route.stream
+	if stream == nil {
+		return appendSequenceGeneration{}, false
+	}
+	stream.mu.Lock()
+	pending := stream.PendingKVAcks[message.GetId()]
+	if pending == nil {
+		stream.mu.Unlock()
+		if completed, found := service.lookupKVAckRoute(requestID, message.GetId()); found && completed.completed {
+			return completed.appendGeneration, true
+		}
+		return appendSequenceGeneration{}, false
+	}
+	if pending.kind == pendingKVOperationSetBlob {
+		var resultErr error
+		if result := message.GetSetBlobResult(); result == nil {
+			resultErr = fmt.Errorf("client returned unexpected KV result for SetBlob")
+		} else if resultError := result.GetError(); resultError != nil {
+			resultErr = fmt.Errorf("client rejected blob: %s", strings.TrimSpace(resultError.GetMessage()))
+		}
+		delete(stream.PendingKVAcks, pending.id)
+		stream.mu.Unlock()
+		pending.complete(resultErr)
+		return service.completedKVAckGeneration(requestID, pending.id)
+	}
+	stream.mu.Unlock()
+
+	var resultErr error
+	result := message.GetGetBlobResult()
+	if pending.kind != pendingKVOperationGetBlob || result == nil {
+		resultErr = fmt.Errorf("client returned unexpected KV result for GetBlob")
+	} else {
+		blobData := result.GetBlobData()
+		if _, err := validatedBlobDigest(pending.digest[:], blobData); err != nil {
+			resultErr = fmt.Errorf("validate client blob: %w", err)
+		} else if err := service.putConversationBlobWithRecovery(pending.digest[:], blobData); err != nil {
+			resultErr = fmt.Errorf("store client blob: %w", err)
+		}
+	}
+	stream.mu.Lock()
+	if stream.PendingKVAcks[pending.id] == pending {
+		delete(stream.PendingKVAcks, pending.id)
+	}
+	stream.mu.Unlock()
+	service.clearRequestedConversationBlobEvents(stream, []*pendingKVAck{pending})
+	pending.complete(resultErr)
+	return service.completedKVAckGeneration(requestID, pending.id)
+}
+
+func (service *Service) completedKVAckGeneration(requestID string, id uint32) (appendSequenceGeneration, bool) {
+	route, ok := service.lookupKVAckRoute(requestID, id)
+	if !ok || !route.completed {
+		return appendSequenceGeneration{}, false
+	}
+	return route.appendGeneration, true
+}
+
+func (service *Service) lookupKVAckRoute(requestID string, id uint32) (kvAckRoute, bool) {
+	if service == nil || id == 0 {
+		return kvAckRoute{}, false
+	}
+	requestID = strings.TrimSpace(requestID)
+	service.kvAckMu.Lock()
+	route, ok := service.kvAckRoutes[id]
+	if ok && route.createdAt.Before(time.Now().UTC().Add(-completedKVAckRetention)) {
+		delete(service.kvAckRoutes, id)
+		ok = false
+	}
+	service.kvAckMu.Unlock()
+	if !ok || route.requestID != requestID {
+		return kvAckRoute{}, false
+	}
+	return route, true
+}
+
+func (service *Service) hasKVAckRoute(id uint32) bool {
+	if service == nil || id == 0 {
+		return false
+	}
+	service.kvAckMu.Lock()
+	defer service.kvAckMu.Unlock()
+	route, ok := service.kvAckRoutes[id]
+	if ok && route.createdAt.Before(time.Now().UTC().Add(-completedKVAckRetention)) {
+		delete(service.kvAckRoutes, id)
+		return false
+	}
+	return ok
+}
+
+func (service *Service) registerKVAckRoute(id uint32, stream *ActiveStream, kind pendingKVOperation) {
+	if service == nil || id == 0 || stream == nil {
+		return
+	}
+	now := time.Now().UTC()
+	cutoff := now.Add(-completedKVAckRetention)
+	service.kvAckMu.Lock()
+	generation := service.appendSeq.CaptureGeneration(stream.RequestID)
+	if service.kvAckRoutes == nil {
+		service.kvAckRoutes = make(map[uint32]kvAckRoute)
+	}
+	for routeID, route := range service.kvAckRoutes {
+		if route.createdAt.Before(cutoff) {
+			delete(service.kvAckRoutes, routeID)
+		}
+	}
+	route := kvAckRoute{
+		requestID:        strings.TrimSpace(stream.RequestID),
+		stream:           stream,
+		streamInstanceID: stream.InstanceID,
+		kind:             kind,
+		appendGeneration: generation,
+		createdAt:        now,
+	}
+	for _, existing := range service.kvAckRoutes {
+		if sameKVAckRouteGeneration(existing, route) && existing.restartDone != nil {
+			route.restartDone = existing.restartDone
+			break
+		}
+	}
+	service.kvAckRoutes[id] = route
+	service.kvAckMu.Unlock()
+}
+
+func (service *Service) completeKVAckRoute(id uint32) {
+	if service == nil || id == 0 {
+		return
+	}
+	service.kvAckMu.Lock()
+	route, ok := service.kvAckRoutes[id]
+	if ok {
+		route.stream = nil
+		route.completed = true
+		route.createdAt = time.Now().UTC()
+		service.kvAckRoutes[id] = route
+	}
+	service.kvAckMu.Unlock()
+}
+
+func (service *Service) kvAckMessageMatches(requestID string, message *agentv1.KvClientMessage) bool {
+	if service == nil || message == nil {
+		return false
+	}
+	route, ok := service.lookupKVAckRoute(requestID, message.GetId())
+	return ok && kvAckRouteMatchesMessage(route, message)
+}
+
+func (service *Service) trackKVAckAppendSequence(requestID string, message *agentv1.KvClientMessage, appendSeq int64, fingerprint [sha256.Size]byte) bool {
+	if service == nil || message == nil || appendSeq <= 0 {
+		return false
+	}
+	requestID = strings.TrimSpace(requestID)
+	service.kvAckMu.Lock()
+	defer service.kvAckMu.Unlock()
+	route, ok := service.kvAckRoutes[message.GetId()]
+	if !ok || route.requestID != requestID || route.createdAt.Before(time.Now().UTC().Add(-completedKVAckRetention)) || !kvAckRouteMatchesMessage(route, message) {
+		return false
+	}
+	if route.appendSequences == nil {
+		route.appendSequences = make(map[kvAckAppendSequenceKey]appendSequenceGeneration)
+	}
+	route.appendSequences[kvAckAppendSequenceKey{appendSeq: appendSeq, fingerprint: fingerprint}] = route.appendGeneration
+	service.kvAckRoutes[message.GetId()] = route
+	return true
+}
+
+func (service *Service) completeTrackedKVAckAppendSequence(requestID string, id uint32, appendSeq int64, fingerprint [sha256.Size]byte) (bool, appendSequenceCompletion) {
+	if service == nil || appendSeq <= 0 {
+		return false, appendSequenceCompletion{}
+	}
+	requestID = strings.TrimSpace(requestID)
+	key := kvAckAppendSequenceKey{appendSeq: appendSeq, fingerprint: fingerprint}
+	for attempt := 0; attempt < 3; attempt++ {
+		service.kvAckMu.Lock()
+		route, ok := service.kvAckRoutes[id]
+		if !ok || route.requestID != requestID {
+			service.kvAckMu.Unlock()
+			return false, appendSequenceCompletion{}
+		}
+		generation := route.appendGeneration
+		if observedGeneration, tracked := route.appendSequences[key]; tracked {
+			generation = observedGeneration
+		}
+		service.kvAckMu.Unlock()
+		matched, completion := service.completeAppendAheadForGeneration(requestID, appendSeq, generation, fingerprint)
+		if matched {
+			return true, completion
+		}
+	}
+	return false, appendSequenceCompletion{}
+}
+
+func kvAckRouteMatchesMessage(route kvAckRoute, message *agentv1.KvClientMessage) bool {
+	if message == nil {
+		return false
+	}
+	switch route.kind {
+	case pendingKVOperationSetBlob:
+		return message.GetSetBlobResult() != nil
+	case pendingKVOperationGetBlob:
+		return message.GetGetBlobResult() != nil
+	default:
+		return false
+	}
+}
+
+func sameKVAckRouteGeneration(left kvAckRoute, right kvAckRoute) bool {
+	return left.requestID == right.requestID &&
+		left.streamInstanceID == right.streamInstanceID &&
+		left.appendGeneration == right.appendGeneration
+}
+
+func (service *Service) beginAppendSequenceReplayRestart(requestID string, appendSeq int64, fingerprint [sha256.Size]byte) kvAckRestartToken {
+	if service == nil || service.appendSeq == nil {
+		return kvAckRestartToken{}
+	}
+	generation, candidate := service.appendSeq.ReplayRestartCandidate(requestID, appendSeq, fingerprint)
+	if !candidate {
+		return kvAckRestartToken{}
+	}
+	return service.beginKVAckSequenceRestartForGeneration(requestID, generation)
+}
+
+func (service *Service) beginKVAckSequenceRestartForGeneration(requestID string, generation appendSequenceGeneration) kvAckRestartToken {
+	if service == nil || generation.state == nil || service.broker == nil {
+		return kvAckRestartToken{}
+	}
+	requestID = strings.TrimSpace(requestID)
+	stream, ok := service.broker.Get(requestID)
+	if !ok || stream == nil {
+		return kvAckRestartToken{}
+	}
+	streamInstanceID := stream.InstanceID
+	service.kvAckMu.Lock()
+	defer service.kvAckMu.Unlock()
+
+	var token kvAckRestartToken
+	for _, route := range service.kvAckRoutes {
+		if route.requestID != requestID || route.streamInstanceID != streamInstanceID || route.appendGeneration != generation {
+			continue
+		}
+		token = kvAckRestartToken{
+			requestID:        requestID,
+			streamInstanceID: streamInstanceID,
+			appendGeneration: generation,
+			done:             route.restartDone,
+		}
+		break
+	}
+	if token.appendGeneration.state == nil {
+		return kvAckRestartToken{}
+	}
+	if token.done == nil {
+		token.done = make(chan struct{})
+	}
+	for id, route := range service.kvAckRoutes {
+		if route.requestID == token.requestID &&
+			route.streamInstanceID == token.streamInstanceID &&
+			route.appendGeneration == token.appendGeneration {
+			route.restartDone = token.done
+			service.kvAckRoutes[id] = route
+		}
+	}
+	return token
+}
+
+func (service *Service) completeAppendAheadForGeneration(requestID string, appendSeq int64, generation appendSequenceGeneration, fingerprint [sha256.Size]byte) (bool, appendSequenceCompletion) {
+	token := service.beginAppendSequenceReplayRestart(requestID, appendSeq, fingerprint)
+	matched, completion := service.appendSeq.CompleteAheadForGenerationWithFingerprint(requestID, appendSeq, generation, &fingerprint)
+	if !matched || completion.retry || !completion.replayRestarted {
+		service.abortKVAckSequenceRestart(token)
+		return matched, completion
+	}
+	service.adoptKVAckSequenceRestart(token, completion.generation)
+	return matched, completion
+}
+
+func (service *Service) finishAppendSequenceReplayRestart(token kvAckRestartToken, ticket appendSequenceTicket) {
+	if token.done != nil && token.appendGeneration != ticket.Generation() {
+		service.adoptKVAckSequenceRestart(token, ticket.Generation())
+		return
+	}
+	service.abortKVAckSequenceRestart(token)
+}
+
+func (service *Service) abortKVAckSequenceRestart(token kvAckRestartToken) {
+	if service == nil || token.done == nil {
+		return
+	}
+	service.kvAckMu.Lock()
+	matched := false
+	for id, route := range service.kvAckRoutes {
+		if route.requestID != token.requestID ||
+			route.streamInstanceID != token.streamInstanceID ||
+			route.appendGeneration != token.appendGeneration ||
+			route.restartDone != token.done {
+			continue
+		}
+		route.restartDone = nil
+		service.kvAckRoutes[id] = route
+		matched = true
+	}
+	if matched {
+		close(token.done)
+	}
+	service.kvAckMu.Unlock()
+}
+
+func (service *Service) beginKVAckSequenceRestart(requestID string, message *agentv1.KvClientMessage) kvAckRestartToken {
+	if service == nil || message == nil {
+		return kvAckRestartToken{}
+	}
+	requestID = strings.TrimSpace(requestID)
+	now := time.Now().UTC()
+	service.kvAckMu.Lock()
+	defer service.kvAckMu.Unlock()
+	route, ok := service.kvAckRoutes[message.GetId()]
+	if !ok || route.requestID != requestID || route.createdAt.Before(now.Add(-completedKVAckRetention)) || !kvAckRouteMatchesMessage(route, message) {
+		return kvAckRestartToken{}
+	}
+	token := kvAckRestartToken{
+		requestID:        route.requestID,
+		streamInstanceID: route.streamInstanceID,
+		appendGeneration: route.appendGeneration,
+		done:             route.restartDone,
+	}
+	if token.done != nil {
+		return token
+	}
+	token.done = make(chan struct{})
+	for id, candidate := range service.kvAckRoutes {
+		if sameKVAckRouteGeneration(candidate, route) {
+			candidate.restartDone = token.done
+			service.kvAckRoutes[id] = candidate
+		}
+	}
+	return token
+}
+
+func (service *Service) adoptKVAckSequenceRestart(token kvAckRestartToken, generation appendSequenceGeneration) bool {
+	if service == nil || token.done == nil || generation.state == nil {
+		return false
+	}
+	service.kvAckMu.Lock()
+	matched := false
+	for id, route := range service.kvAckRoutes {
+		if route.requestID != token.requestID ||
+			route.streamInstanceID != token.streamInstanceID ||
+			route.appendGeneration != token.appendGeneration ||
+			route.restartDone != token.done {
+			continue
+		}
+		route.appendGeneration = generation
+		route.restartDone = nil
+		service.kvAckRoutes[id] = route
+		matched = true
+	}
+	if matched {
+		close(token.done)
+	}
+	service.kvAckMu.Unlock()
+	return matched
+}
+
+func (service *Service) newPendingKVAckLocked(stream *ActiveStream, digest [sha256.Size]byte, kind pendingKVOperation, notify chan<- struct{}) *pendingKVAck {
+	for {
+		id := service.nextKVMessageID.Add(1)
+		if id == 0 {
+			continue
+		}
+		if _, exists := stream.PendingKVAcks[id]; exists {
+			continue
+		}
+		if service.hasKVAckRoute(id) {
+			continue
+		}
+		pending := &pendingKVAck{
+			id:     id,
+			digest: digest,
+			kind:   kind,
+			done:   make(chan struct{}),
+			notify: notify,
+		}
+		pending.onComplete = func() {
+			service.completeKVAckRoute(id)
+		}
+		stream.PendingKVAcks[id] = pending
+		service.registerKVAckRoute(id, stream, kind)
+		return pending
+	}
+}
+
+func rememberDeliveredBlobAcks(messages []pendingBlobMessage, delivered map[[sha256.Size]byte]struct{}) {
+	if delivered == nil {
+		return
+	}
+	for _, item := range messages {
+		if item.ack == nil {
+			continue
+		}
+		select {
+		case <-item.ack.done:
+			if item.ack.result() == nil {
+				delivered[item.ack.digest] = struct{}{}
+			}
+		default:
+		}
+	}
+}
+
+func (pending *pendingKVAck) complete(err error) {
+	if pending == nil {
+		return
+	}
+	pending.once.Do(func() {
+		pending.err = err
+		if pending.onComplete != nil {
+			pending.onComplete()
+		}
+		close(pending.done)
+		if pending.notify != nil {
+			select {
+			case pending.notify <- struct{}{}:
+			default:
+			}
+		}
+	})
+}
+
+func (pending *pendingKVAck) result() error {
+	if pending == nil {
+		return nil
+	}
+	<-pending.done
+	return pending.err
+}
+
+func (service *Service) waitForKVAcks(ctx context.Context, acks []*pendingKVAck) error {
+	if len(acks) == 0 {
+		return nil
+	}
+	type ackResult struct {
+		pending *pendingKVAck
+		err     error
+	}
+	results := make(chan ackResult, len(acks))
+	remaining := 0
+	for _, pending := range acks {
+		if pending == nil {
+			continue
+		}
+		remaining++
+		go func(item *pendingKVAck) {
+			results <- ackResult{pending: item, err: item.result()}
+		}(pending)
+	}
+	if remaining == 0 {
+		return nil
+	}
+	idleTimer := time.NewTimer(conversationBlobAckTimeout)
+	defer idleTimer.Stop()
+	batchTimer := time.NewTimer(conversationBlobAckBatchTimeout)
+	defer batchTimer.Stop()
+	for remaining > 0 {
+		select {
+		case result := <-results:
+			remaining--
+			if result.err != nil {
+				return fmt.Errorf("conversation blob acknowledgement %d failed: %w", result.pending.id, result.err)
+			}
+			if remaining > 0 {
+				if !idleTimer.Stop() {
+					select {
+					case <-idleTimer.C:
+					default:
+					}
+				}
+				idleTimer.Reset(conversationBlobAckTimeout)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-idleTimer.C:
+			return fmt.Errorf("timed out waiting for conversation blob acknowledgements: %d remaining", remaining)
+		case <-batchTimer.C:
+			return fmt.Errorf("conversation blob acknowledgement batch exceeded %s: %d remaining", conversationBlobAckBatchTimeout, remaining)
+		}
+	}
+	return nil
+}
+
+func buildSetBlobMessage(id uint32, blob CheckpointBlob) *agentv1.AgentServerMessage {
+	return &agentv1.AgentServerMessage{
+		Message: &agentv1.AgentServerMessage_KvServerMessage{
+			KvServerMessage: &agentv1.KvServerMessage{
+				Id: id,
+				Message: &agentv1.KvServerMessage_SetBlobArgs{
+					SetBlobArgs: &agentv1.SetBlobArgs{
+						BlobId:   append([]byte(nil), blob.ID...),
+						BlobData: append([]byte(nil), blob.Data...),
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGetBlobMessage(id uint32, blobID []byte) *agentv1.AgentServerMessage {
+	return &agentv1.AgentServerMessage{
+		Message: &agentv1.AgentServerMessage_KvServerMessage{
+			KvServerMessage: &agentv1.KvServerMessage{
+				Id: id,
+				Message: &agentv1.KvServerMessage_GetBlobArgs{
+					GetBlobArgs: &agentv1.GetBlobArgs{BlobId: append([]byte(nil), blobID...)},
+				},
+			},
+		},
+	}
+}
+
+func checkpointBlobRetryDelay(failures int) time.Duration {
+	if failures <= 0 {
+		return 0
+	}
+	shift := failures - 1
+	if shift > 5 {
+		shift = 5
+	}
+	delay := conversationBlobRetryBase * time.Duration(1<<shift)
+	if delay > conversationBlobRetryMax {
+		return conversationBlobRetryMax
+	}
+	return delay
+}
+
+func (service *Service) checkpointBlobDeliveryAborted(stream *ActiveStream) bool {
+	if service == nil || stream == nil {
+		return true
+	}
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	return stream.Status == StreamStatusCanceled || stream.Status == StreamStatusFailed
+}
+
+func (service *Service) waitForCheckpointBlobRetry(ctx context.Context, signal <-chan struct{}, stream *ActiveStream, retryAt time.Time) error {
+	for {
+		wait := time.Until(retryAt)
+		if wait <= 0 || service.checkpointBlobDeliveryAborted(stream) {
+			return nil
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-signal:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
+			return nil
+		}
+	}
+}
+
+type conversationBlobResolution struct {
+	data    []byte
+	missing bool
+}
+
+type conversationStateMaterialization struct {
+	state           *agentv1.ConversationStateStructure
+	missing         int
+	missingIDs      map[[sha256.Size]byte]struct{}
+	rootMissing     bool
+	rootComplete    bool
+	turnMissing     bool
+	summaryMissing  bool
+	requiredMissing bool
+}
+
+func (service *Service) resolveConversationBlob(reference []byte, field string) (conversationBlobResolution, error) {
+	if len(reference) == 0 || len(reference) != sha256.Size {
+		return conversationBlobResolution{data: append([]byte(nil), reference...)}, nil
+	}
+	if service == nil || service.blobStore == nil {
+		return conversationBlobResolution{}, fmt.Errorf("resolve %s blob: conversation blob store is not available", field)
+	}
+	data, err := service.blobStore.Get(reference)
+	if err == nil {
+		return conversationBlobResolution{data: data}, nil
+	}
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, errConversationBlobCorrupt) {
+		return conversationBlobResolution{data: append([]byte(nil), reference...), missing: true}, nil
+	}
+	return conversationBlobResolution{}, fmt.Errorf("resolve %s blob %s: %w", field, hex.EncodeToString(reference), err)
+}
+
+func (service *Service) materializeConversationState(ctx context.Context, stream *ActiveStream, state *agentv1.ConversationStateStructure) (*agentv1.ConversationStateStructure, error) {
+	if state == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	idleTimer := time.NewTimer(conversationBlobImportIdleTime)
+	defer idleTimer.Stop()
+	poll := time.NewTicker(conversationBlobImportPoll)
+	defer poll.Stop()
+	progress := make(chan struct{}, 1)
+	requested := make(map[[sha256.Size]byte]*pendingKVAck)
+	defer func() {
+		pending := make([]*pendingKVAck, 0, len(requested))
+		for _, item := range requested {
+			pending = append(pending, item)
+		}
+		service.clearRequestedConversationBlobEvents(stream, pending)
+		service.cancelPendingKVAcks(stream, pending, context.Canceled)
+	}()
+	result, err := service.materializeConversationStateOnce(state)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		if result.missing == 0 {
+			return result.state, nil
+		}
+		if err := service.requestMissingConversationBlobs(stream, result.missingIDs, requested, progress); err != nil {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-progress:
+			drainConversationBlobProgress(progress)
+			resetConversationBlobIdleTimer(idleTimer)
+			result, err = service.materializeConversationStateOnce(state)
+			if err != nil {
+				return nil, err
+			}
+		case <-poll.C:
+			result, err = service.materializeConversationStateOnce(state)
+			if err != nil {
+				return nil, err
+			}
+		case <-idleTimer.C:
+			select {
+			case <-progress:
+				drainConversationBlobProgress(progress)
+				resetConversationBlobIdleTimer(idleTimer)
+				result, err = service.materializeConversationStateOnce(state)
+				if err != nil {
+					return nil, err
+				}
+				continue
+			default:
+			}
+			latest, err := service.materializeConversationStateOnce(state)
+			if err != nil {
+				return nil, err
+			}
+			return finalizeConversationStateMaterialization(latest)
+		}
+	}
+}
+
+func drainConversationBlobProgress(progress <-chan struct{}) {
+	for {
+		select {
+		case <-progress:
+		default:
+			return
+		}
+	}
+}
+
+func resetConversationBlobIdleTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(conversationBlobImportIdleTime)
+}
+
+func (service *Service) clearRequestedConversationBlobEvents(stream *ActiveStream, pending []*pendingKVAck) {
+	if stream == nil || len(pending) == 0 {
+		return
+	}
+	ids := make(map[uint32]struct{}, len(pending))
+	for _, item := range pending {
+		if item != nil && item.kind == pendingKVOperationGetBlob {
+			ids[item.id] = struct{}{}
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	stream.mu.Lock()
+	for index := len(stream.Backlog) - 1; index >= 0 && len(ids) > 0; index-- {
+		message := stream.Backlog[index].Message
+		kvMessage := message.GetKvServerMessage()
+		if kvMessage == nil || kvMessage.GetGetBlobArgs() == nil {
+			continue
+		}
+		if _, ok := ids[kvMessage.GetId()]; ok {
+			stream.Backlog[index].Message = nil
+			delete(ids, kvMessage.GetId())
+		}
+	}
+	stream.mu.Unlock()
+}
+
+func (service *Service) requestMissingConversationBlobs(stream *ActiveStream, missing map[[sha256.Size]byte]struct{}, requested map[[sha256.Size]byte]*pendingKVAck, progress chan<- struct{}) error {
+	if len(missing) == 0 || stream == nil {
+		return nil
+	}
+	if service == nil || service.broker == nil {
+		return fmt.Errorf("conversation blob retrieval is not available")
+	}
+	type request struct {
+		digest  [sha256.Size]byte
+		pending *pendingKVAck
+	}
+	inFlight := 0
+	for _, pending := range requested {
+		if pending == nil {
+			continue
+		}
+		select {
+		case <-pending.done:
+		default:
+			inFlight++
+		}
+	}
+	available := conversationBlobGetMaxInFlight - inFlight
+	if available <= 0 {
+		return nil
+	}
+	digests := make([][sha256.Size]byte, 0, len(missing))
+	for digest := range missing {
+		if _, ok := requested[digest]; !ok {
+			digests = append(digests, digest)
+		}
+	}
+	sort.Slice(digests, func(i int, j int) bool {
+		return bytes.Compare(digests[i][:], digests[j][:]) < 0
+	})
+	if len(digests) > available {
+		digests = digests[:available]
+	}
+	requests := make([]request, 0, len(digests))
+	stream.mu.Lock()
+	if isTerminalStreamStatus(stream.Status) {
+		stream.mu.Unlock()
+		return context.Canceled
+	}
+	if stream.PendingKVAcks == nil {
+		stream.PendingKVAcks = make(map[uint32]*pendingKVAck)
+	}
+	for _, digest := range digests {
+		pending := service.newPendingKVAckLocked(stream, digest, pendingKVOperationGetBlob, progress)
+		requested[digest] = pending
+		requests = append(requests, request{digest: digest, pending: pending})
+	}
+	stream.mu.Unlock()
+	for _, item := range requests {
+		if err := service.broker.publishToStream(stream.RequestID, stream.InstanceID, StreamEvent{
+			Message: buildGetBlobMessage(item.pending.id, item.digest[:]),
+		}); err != nil {
+			pending := make([]*pendingKVAck, 0, len(requests))
+			for _, request := range requests {
+				pending = append(pending, request.pending)
+			}
+			service.cancelPendingKVAcks(stream, pending, err)
+			return fmt.Errorf("request conversation blob %s: %w", hex.EncodeToString(item.digest[:]), err)
+		}
+	}
+	return nil
+}
+
+func (service *Service) materializeConversationStateOnce(state *agentv1.ConversationStateStructure) (conversationStateMaterialization, error) {
+	materialized, ok := proto.Clone(state).(*agentv1.ConversationStateStructure)
+	if !ok || materialized == nil {
+		return conversationStateMaterialization{}, fmt.Errorf("clone conversation state")
+	}
+	result := conversationStateMaterialization{
+		state:      materialized,
+		missingIDs: make(map[[sha256.Size]byte]struct{}),
+	}
+	markMissing := func(reference []byte) {
+		if digest, err := parseBlobDigest(reference); err == nil {
+			result.missingIDs[digest] = struct{}{}
+		}
+	}
+	resolveJSONList := func(items [][]byte, field string) ([][]byte, int, error) {
+		result := make([][]byte, 0, len(items))
+		missing := 0
+		for index, item := range items {
+			resolved, err := service.resolveConversationBlob(item, fmt.Sprintf("%s[%d]", field, index))
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(resolved.data) == 0 {
+				continue
+			}
+			if !json.Valid(resolved.data) {
+				if resolved.missing {
+					markMissing(item)
+					missing++
+					continue
+				}
+				return nil, 0, fmt.Errorf("decode materialized %s[%d] JSON", field, index)
+			}
+			result = append(result, resolved.data)
+		}
+		return result, missing, nil
+	}
+	resolveProtoList := func(items [][]byte, field string, newMessage func() proto.Message) ([][]byte, int, error) {
+		result := make([][]byte, 0, len(items))
+		missing := 0
+		for index, item := range items {
+			resolved, err := service.resolveConversationBlob(item, fmt.Sprintf("%s[%d]", field, index))
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(resolved.data) == 0 {
+				continue
+			}
+			if resolved.missing && !knownProtoPayload(resolved.data, newMessage()) {
+				markMissing(item)
+				missing++
+				continue
+			}
+			result = append(result, resolved.data)
+		}
+		return result, missing, nil
+	}
+	resolveProtoValue := func(reference []byte, field string, newMessage func() proto.Message) ([]byte, bool, error) {
+		resolved, err := service.resolveConversationBlob(reference, field)
+		if err != nil {
+			return nil, false, err
+		}
+		if resolved.missing && !knownProtoPayload(resolved.data, newMessage()) {
+			return nil, true, nil
+		}
+		return resolved.data, false, nil
+	}
+
+	rootPromptMessages, missing, err := resolveJSONList(materialized.GetRootPromptMessagesJson(), "root_prompt_messages_json")
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	materialized.RootPromptMessagesJson = rootPromptMessages
+	result.missing += missing
+	result.rootMissing = missing > 0
+	result.rootComplete = missing == 0 && len(rootPromptMessages) > 0
+
+	materialized.Todos, missing, err = resolveProtoList(materialized.GetTodos(), "todos", func() proto.Message { return &agentv1.TodoItem{} })
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	result.missing += missing
+	result.requiredMissing = result.requiredMissing || missing > 0
+	materialized.SummaryArchives, missing, err = resolveProtoList(materialized.GetSummaryArchives(), "summary_archives", func() proto.Message { return &agentv1.ConversationSummaryArchive{} })
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	result.missing += missing
+	result.requiredMissing = result.requiredMissing || missing > 0
+	summaryReference := materialized.GetSummary()
+	materialized.Summary, result.summaryMissing, err = resolveProtoValue(summaryReference, "summary", func() proto.Message { return &agentv1.ConversationSummary{} })
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	if result.summaryMissing {
+		markMissing(summaryReference)
+		result.missing++
+	}
+	var valueMissing bool
+	summaryArchiveReference := materialized.GetSummaryArchive()
+	materialized.SummaryArchive, valueMissing, err = resolveProtoValue(summaryArchiveReference, "summary_archive", func() proto.Message { return &agentv1.ConversationSummaryArchive{} })
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	if valueMissing {
+		markMissing(summaryArchiveReference)
+		result.missing++
+		result.requiredMissing = true
+	}
+	planReference := materialized.GetPlan()
+	materialized.Plan, valueMissing, err = resolveProtoValue(planReference, "plan", func() proto.Message { return &agentv1.ConversationPlan{} })
+	if err != nil {
+		return conversationStateMaterialization{}, err
+	}
+	if valueMissing {
+		markMissing(planReference)
+		result.missing++
+		result.requiredMissing = true
+	}
+
+	turns := make([][]byte, 0, len(materialized.GetTurns()))
+	for index, turnReference := range materialized.GetTurns() {
+		rawTurn, err := service.resolveConversationBlob(turnReference, fmt.Sprintf("turns[%d]", index))
+		if err != nil {
+			return conversationStateMaterialization{}, err
+		}
+		turn := &agentv1.ConversationTurnStructure{}
+		if err := proto.Unmarshal(rawTurn.data, turn); err != nil || turn.GetTurn() == nil {
+			if rawTurn.missing {
+				markMissing(turnReference)
+				result.missing++
+				result.turnMissing = true
+				continue
+			}
+			return conversationStateMaterialization{}, fmt.Errorf("decode materialized turn %d", index)
+		}
+		skipTurn := false
+		if agentTurn := turn.GetAgentConversationTurn(); agentTurn != nil {
+			userMessageReference := agentTurn.GetUserMessage()
+			userMessage, err := service.resolveConversationBlob(userMessageReference, fmt.Sprintf("turns[%d].user_message", index))
+			if err != nil {
+				return conversationStateMaterialization{}, err
+			}
+			if userMessage.missing && !knownProtoPayload(userMessage.data, &agentv1.UserMessage{}) {
+				markMissing(userMessageReference)
+				result.missing++
+				result.turnMissing = true
+				skipTurn = true
+			} else {
+				agentTurn.UserMessage = userMessage.data
+			}
+			if !skipTurn {
+				steps := make([][]byte, 0, len(agentTurn.GetSteps()))
+				for stepIndex, stepReference := range agentTurn.GetSteps() {
+					step, err := service.resolveConversationBlob(stepReference, fmt.Sprintf("turns[%d].steps[%d]", index, stepIndex))
+					if err != nil {
+						return conversationStateMaterialization{}, err
+					}
+					if step.missing && !knownProtoPayload(step.data, &agentv1.ConversationStep{}) {
+						markMissing(stepReference)
+						result.missing++
+						result.turnMissing = true
+						skipTurn = true
+						break
+					}
+					steps = append(steps, step.data)
+				}
+				agentTurn.Steps = steps
+			}
+		}
+		if skipTurn {
+			continue
+		}
+		encoded, err := proto.Marshal(turn)
+		if err != nil {
+			return conversationStateMaterialization{}, fmt.Errorf("encode materialized turn %d: %w", index, err)
+		}
+		turns = append(turns, encoded)
+	}
+	materialized.Turns = turns
+	return result, nil
+}
+
+func finalizeConversationStateMaterialization(result conversationStateMaterialization) (*agentv1.ConversationStateStructure, error) {
+	if result.state == nil {
+		return nil, fmt.Errorf("materialize conversation state")
+	}
+	if result.rootMissing {
+		result.state.RootPromptMessagesJson = nil
+	}
+	if result.requiredMissing {
+		return nil, fmt.Errorf("conversation state remains incomplete after %s without blob progress: %d blob(s) unavailable", conversationBlobImportIdleTime, result.missing)
+	}
+	if result.turnMissing && !result.rootComplete {
+		return nil, fmt.Errorf("conversation history remains incomplete after %s without blob progress: %d blob(s) unavailable", conversationBlobImportIdleTime, result.missing)
+	}
+	if result.summaryMissing && !result.rootComplete {
+		return nil, fmt.Errorf("conversation history remains incomplete after %s without blob progress: %d blob(s) unavailable", conversationBlobImportIdleTime, result.missing)
+	}
+	if result.rootMissing && !result.rootComplete && len(result.state.GetTurns()) == 0 {
+		return nil, fmt.Errorf("conversation history remains incomplete after %s without blob progress: %d blob(s) unavailable", conversationBlobImportIdleTime, result.missing)
+	}
+	return result.state, nil
+}
+
+func knownProtoPayload(data []byte, message proto.Message) bool {
+	if len(data) == 0 || message == nil {
+		return false
+	}
+	if err := proto.Unmarshal(data, message); err != nil {
+		return false
+	}
+	known := false
+	message.ProtoReflect().Range(func(_ protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		known = true
+		return false
+	})
+	return known
+}

--- a/internal/backend/forwarder/broker.go
+++ b/internal/backend/forwarder/broker.go
@@ -17,9 +17,10 @@ const orphanSubscriberGracePeriod = 30 * time.Second
 const terminalStreamRetentionPeriod = 30 * time.Second
 
 type StreamBroker struct {
-	mu      sync.RWMutex
-	streams map[string]*ActiveStream
-	nextID  atomic.Uint64
+	mu               sync.RWMutex
+	streams          map[string]*ActiveStream
+	nextSubscriberID atomic.Uint64
+	nextStreamID     atomic.Uint64
 }
 
 // NewStreamBroker 创建活动流注册表。
@@ -43,45 +44,61 @@ func (broker *StreamBroker) OpenStream(requestID string, conversationID string, 
 	defer broker.mu.Unlock()
 	if existing, ok := broker.streams[normalizedRequestID]; ok {
 		existing.mu.Lock()
-		existing.ConversationID = strings.TrimSpace(conversationID)
-		existing.TurnSeq = turnSeq
-		existing.ModelID = strings.TrimSpace(modelID)
-		existing.ModelName = strings.TrimSpace(modelName)
-		existing.Mode = normalizedMode
-		existing.LatestUserText = strings.TrimSpace(latestUserText)
-		if existing.Status == "" {
-			existing.Status = StreamStatusCreated
+		if isTerminalStreamStatus(existing.Status) {
+			broker.stopTerminalCleanupTimerLocked(existing)
+			existing.mu.Unlock()
+			delete(broker.streams, normalizedRequestID)
+		} else {
+			existing.ConversationID = strings.TrimSpace(conversationID)
+			existing.TurnSeq = turnSeq
+			existing.ModelID = strings.TrimSpace(modelID)
+			existing.ModelName = strings.TrimSpace(modelName)
+			existing.Mode = normalizedMode
+			existing.LatestUserText = strings.TrimSpace(latestUserText)
+			if existing.Status == "" {
+				existing.Status = StreamStatusCreated
+			}
+			if existing.PendingExecs == nil {
+				existing.PendingExecs = make(map[string]runtimecore.PendingExec)
+			}
+			if existing.PendingInteractions == nil {
+				existing.PendingInteractions = make(map[string]runtimecore.PendingInteraction)
+			}
+			if existing.RecentCompletedInteractions == nil {
+				existing.RecentCompletedInteractions = make(map[uint32]time.Time)
+			}
+			if existing.PartialToolCallIDs == nil {
+				existing.PartialToolCallIDs = make(map[string]struct{})
+			}
+			if existing.PatchEditQueues == nil {
+				existing.PatchEditQueues = make(map[string][]queuedPatchEditOperation)
+			}
+			if existing.BackgroundShells == nil {
+				existing.BackgroundShells = make(map[string]*BackgroundShellState)
+			}
+			if existing.BackgroundShellsByMessageID == nil {
+				existing.BackgroundShellsByMessageID = make(map[uint32]string)
+			}
+			if existing.BackgroundShellsByExecID == nil {
+				existing.BackgroundShellsByExecID = make(map[string]string)
+			}
+			if existing.BackgroundShellActions == nil {
+				existing.BackgroundShellActions = make(map[string]time.Time)
+			}
+			if existing.PendingKVAcks == nil {
+				existing.PendingKVAcks = make(map[uint32]*pendingKVAck)
+			}
+			if existing.PendingTerminalDeliveries == nil {
+				existing.PendingTerminalDeliveries = make(map[string]uint64)
+			}
+			existing.UpdatedAt = time.Now().UTC()
+			existing.mu.Unlock()
+			return existing, nil
 		}
-		if existing.PendingExecs == nil {
-			existing.PendingExecs = make(map[string]runtimecore.PendingExec)
-		}
-		if existing.PendingInteractions == nil {
-			existing.PendingInteractions = make(map[string]runtimecore.PendingInteraction)
-		}
-		if existing.PartialToolCallIDs == nil {
-			existing.PartialToolCallIDs = make(map[string]struct{})
-		}
-		if existing.PatchEditQueues == nil {
-			existing.PatchEditQueues = make(map[string][]queuedPatchEditOperation)
-		}
-		if existing.BackgroundShells == nil {
-			existing.BackgroundShells = make(map[string]*BackgroundShellState)
-		}
-		if existing.BackgroundShellsByMessageID == nil {
-			existing.BackgroundShellsByMessageID = make(map[uint32]string)
-		}
-		if existing.BackgroundShellsByExecID == nil {
-			existing.BackgroundShellsByExecID = make(map[string]string)
-		}
-		if existing.BackgroundShellActions == nil {
-			existing.BackgroundShellActions = make(map[string]time.Time)
-		}
-		existing.UpdatedAt = time.Now().UTC()
-		existing.mu.Unlock()
-		return existing, nil
 	}
 	now := time.Now().UTC()
 	stream := &ActiveStream{
+		InstanceID:                  broker.nextStreamID.Add(1),
 		RequestID:                   normalizedRequestID,
 		ConversationID:              strings.TrimSpace(conversationID),
 		TurnSeq:                     turnSeq,
@@ -98,10 +115,13 @@ func (broker *StreamBroker) OpenStream(requestID string, conversationID string, 
 		PatchEditQueues:             make(map[string][]queuedPatchEditOperation),
 		MCPToolServers:              make(map[string]string),
 		RecentCompletedExecs:        make(map[uint32]time.Time),
+		RecentCompletedInteractions: make(map[uint32]time.Time),
 		BackgroundShells:            make(map[string]*BackgroundShellState),
 		BackgroundShellsByMessageID: make(map[uint32]string),
 		BackgroundShellsByExecID:    make(map[string]string),
 		BackgroundShellActions:      make(map[string]time.Time),
+		PendingKVAcks:               make(map[uint32]*pendingKVAck),
+		PendingTerminalDeliveries:   make(map[string]uint64),
 		CreatedAt:                   now,
 		UpdatedAt:                   now,
 	}
@@ -120,32 +140,34 @@ func (broker *StreamBroker) Get(requestID string) (*ActiveStream, bool) {
 	return stream, ok
 }
 
-// Subscribe 为指定 request 注册一个新订阅者，并返回用于唤醒 backlog 消费的信号通道。
-func (broker *StreamBroker) Subscribe(requestID string) (string, <-chan struct{}, error) {
+// Subscribe 为指定 request 注册一个新订阅者，并返回对应流与 backlog 唤醒信号。
+func (broker *StreamBroker) Subscribe(requestID string) (*ActiveStream, string, <-chan struct{}, error) {
 	normalizedRequestID := strings.TrimSpace(requestID)
 	if normalizedRequestID == "" {
-		return "", nil, fmt.Errorf("request_id is required")
+		return nil, "", nil, fmt.Errorf("request_id is required")
 	}
-	stream, ok := broker.Get(normalizedRequestID)
-	if !ok || stream == nil {
-		// RunSSE 可能先于 BidiAppend 到达。此时先创建一个占位活动流，
-		// 等待后续上行把真实 conversation/model/mode 信息补齐。
-		var err error
-		stream, err = broker.OpenStream(normalizedRequestID, "", 0, "", "", agentv1.AgentMode_AGENT_MODE_AGENT, "")
-		if err != nil {
-			return "", nil, err
+	for {
+		broker.mu.Lock()
+		stream := broker.streams[normalizedRequestID]
+		if stream == nil {
+			broker.mu.Unlock()
+			// RunSSE 可能先于 BidiAppend 到达。此时先创建一个占位活动流，
+			// 等待后续上行把真实 conversation/model/mode 信息补齐。
+			if _, err := broker.OpenStream(normalizedRequestID, "", 0, "", "", agentv1.AgentMode_AGENT_MODE_AGENT, ""); err != nil {
+				return nil, "", nil, err
+			}
+			continue
 		}
+		subscriberID := fmt.Sprintf("sub-%d", broker.nextSubscriberID.Add(1))
+		subscriber := &StreamSubscriber{Signal: make(chan struct{}, subscriberSignalBufferSize)}
+		stream.mu.Lock()
+		broker.stopTerminalCleanupTimerLocked(stream)
+		stream.Subscribers[subscriberID] = subscriber
+		stream.UpdatedAt = time.Now().UTC()
+		stream.mu.Unlock()
+		broker.mu.Unlock()
+		return stream, subscriberID, subscriber.Signal, nil
 	}
-	subscriberID := fmt.Sprintf("sub-%d", broker.nextID.Add(1))
-	subscriber := &StreamSubscriber{Signal: make(chan struct{}, subscriberSignalBufferSize)}
-
-	stream.mu.Lock()
-	broker.stopTerminalCleanupTimerLocked(stream)
-	stream.Subscribers[subscriberID] = subscriber
-	stream.UpdatedAt = time.Now().UTC()
-	stream.mu.Unlock()
-
-	return subscriberID, subscriber.Signal, nil
 }
 
 func (broker *StreamBroker) stopTerminalCleanupTimerLocked(stream *ActiveStream) {
@@ -159,20 +181,37 @@ func (broker *StreamBroker) stopTerminalCleanupTimerLocked(stream *ActiveStream)
 	}
 }
 
-// Unsubscribe 移除并关闭指定订阅者，并返回移除后的剩余订阅者数量。
-func (broker *StreamBroker) Unsubscribe(requestID string, subscriberID string) int {
-	stream, ok := broker.Get(requestID)
-	if !ok || stream == nil {
-		return 0
+type streamUnsubscribeResult struct {
+	Remaining int
+	Terminal  bool
+	Retain    bool
+}
+
+// Unsubscribe 移除指定流实例上的订阅者，并登记该连接的终态交付结果。
+func (broker *StreamBroker) Unsubscribe(stream *ActiveStream, subscriberID string, terminalObserved bool, completionRegistered bool, terminalEpoch uint64) streamUnsubscribeResult {
+	if stream == nil {
+		return streamUnsubscribeResult{}
 	}
-	remaining := 0
+	result := streamUnsubscribeResult{}
 	stream.mu.Lock()
 	if _, ok := stream.Subscribers[strings.TrimSpace(subscriberID)]; ok {
 		delete(stream.Subscribers, strings.TrimSpace(subscriberID))
 	}
-	remaining = len(stream.Subscribers)
+	result.Remaining = len(stream.Subscribers)
+	result.Terminal = isTerminalStreamStatus(stream.Status)
+	if result.Terminal {
+		if terminalObserved && terminalEpoch == stream.TerminalEpoch && completionRegistered {
+			if stream.PendingTerminalDeliveries == nil {
+				stream.PendingTerminalDeliveries = make(map[string]uint64)
+			}
+			stream.PendingTerminalDeliveries[strings.TrimSpace(subscriberID)] = terminalEpoch
+		} else {
+			stream.TerminalReplayRequired = true
+		}
+	}
+	result.Retain = stream.TerminalReplayRequired || len(stream.PendingTerminalDeliveries) > 0
 	stream.mu.Unlock()
-	return remaining
+	return result
 }
 
 func (broker *StreamBroker) OtherConversationRequestIDs(conversationID string, keepRequestID string) []string {
@@ -219,6 +258,14 @@ func (broker *StreamBroker) scheduleTerminalCleanup(requestID string) bool {
 	if !ok || stream == nil {
 		return false
 	}
+	return broker.scheduleTerminalCleanupForStream(requestID, stream.InstanceID)
+}
+
+func (broker *StreamBroker) scheduleTerminalCleanupForStream(requestID string, instanceID uint64) bool {
+	stream, ok := broker.Get(requestID)
+	if !ok || stream == nil || stream.InstanceID != instanceID {
+		return false
+	}
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
 	if len(stream.Subscribers) > 0 {
@@ -234,15 +281,15 @@ func (broker *StreamBroker) scheduleTerminalCleanup(requestID string) bool {
 		stream.TerminalCleanupTimer.Stop()
 	}
 	stream.TerminalCleanupTimer = time.AfterFunc(terminalStreamRetentionPeriod, func() {
-		broker.runScheduledTerminalCleanup(requestID, sequence)
+		broker.runScheduledTerminalCleanup(requestID, instanceID, sequence)
 	})
 	stream.UpdatedAt = time.Now().UTC()
 	return true
 }
 
-func (broker *StreamBroker) runScheduledTerminalCleanup(requestID string, sequence uint64) {
+func (broker *StreamBroker) runScheduledTerminalCleanup(requestID string, instanceID uint64, sequence uint64) {
 	stream, ok := broker.Get(requestID)
-	if !ok || stream == nil {
+	if !ok || stream == nil || stream.InstanceID != instanceID {
 		return
 	}
 	stream.mu.Lock()
@@ -260,11 +307,15 @@ func (broker *StreamBroker) runScheduledTerminalCleanup(requestID string, sequen
 		return
 	}
 	stream.mu.Unlock()
-	broker.RemoveIfIdle(requestID)
+	broker.removeIfIdleForStream(requestID, instanceID)
 }
 
 // RemoveIfIdle 在没有订阅者时移除终态流，或移除仍为空壳的占位流。
 func (broker *StreamBroker) RemoveIfIdle(requestID string) bool {
+	return broker.removeIfIdleForStream(requestID, 0)
+}
+
+func (broker *StreamBroker) removeIfIdleForStream(requestID string, instanceID uint64) bool {
 	normalizedRequestID := strings.TrimSpace(requestID)
 	if normalizedRequestID == "" {
 		return false
@@ -273,6 +324,9 @@ func (broker *StreamBroker) RemoveIfIdle(requestID string) bool {
 	defer broker.mu.Unlock()
 	stream, ok := broker.streams[normalizedRequestID]
 	if !ok || stream == nil {
+		return false
+	}
+	if instanceID != 0 && stream.InstanceID != instanceID {
 		return false
 	}
 	stream.mu.Lock()
@@ -301,13 +355,21 @@ func (broker *StreamBroker) RemoveIfIdle(requestID string) bool {
 
 // Publish 把一个事件写入 backlog，并唤醒当前所有订阅者读取 backlog。
 func (broker *StreamBroker) Publish(requestID string, event StreamEvent) error {
-	stream, ok := broker.Get(requestID)
-	if !ok || stream == nil {
+	return broker.publishToStream(requestID, 0, event)
+}
+
+func (broker *StreamBroker) publishToStream(requestID string, instanceID uint64, event StreamEvent) error {
+	normalizedRequestID := strings.TrimSpace(requestID)
+	broker.mu.RLock()
+	stream, ok := broker.streams[normalizedRequestID]
+	if !ok || stream == nil || (instanceID != 0 && stream.InstanceID != instanceID) {
+		broker.mu.RUnlock()
 		return fmt.Errorf("request is not active: %s", strings.TrimSpace(requestID))
 	}
 	stream.mu.Lock()
 	if !event.End && isTerminalStreamStatus(stream.Status) {
 		stream.mu.Unlock()
+		broker.mu.RUnlock()
 		return nil
 	}
 	stream.Backlog = append(stream.Backlog, event)
@@ -317,6 +379,7 @@ func (broker *StreamBroker) Publish(requestID string, event StreamEvent) error {
 		subscribers = append(subscribers, subscriber)
 	}
 	stream.mu.Unlock()
+	broker.mu.RUnlock()
 
 	for _, subscriber := range subscribers {
 		if subscriber == nil {
@@ -336,6 +399,15 @@ func (broker *StreamBroker) ReadFromCursor(requestID string, cursor int) ([]Stre
 	if !ok || stream == nil {
 		return nil, fmt.Errorf("request is not active: %s", strings.TrimSpace(requestID))
 	}
+	return broker.ReadFromStreamCursor(stream, cursor)
+}
+
+// ReadFromStreamCursor reads one immutable stream instance even when the same
+// request ID has already started a later lifecycle.
+func (broker *StreamBroker) ReadFromStreamCursor(stream *ActiveStream, cursor int) ([]StreamEvent, error) {
+	if stream == nil {
+		return nil, fmt.Errorf("request stream is not available")
+	}
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
 	if cursor < 0 {
@@ -347,33 +419,52 @@ func (broker *StreamBroker) ReadFromCursor(requestID string, cursor int) ([]Stre
 	return append([]StreamEvent(nil), stream.Backlog[cursor:]...), nil
 }
 
+// CompleteTerminalDelivery resolves one subscriber's Connect endstream write.
+func (broker *StreamBroker) CompleteTerminalDelivery(requestID string, instanceID uint64, subscriberID string, terminalEpoch uint64, delivered bool) {
+	stream, ok := broker.Get(requestID)
+	if !ok || stream == nil || stream.InstanceID != instanceID {
+		return
+	}
+	stream.mu.Lock()
+	pendingEpoch, pending := stream.PendingTerminalDeliveries[strings.TrimSpace(subscriberID)]
+	if !pending || pendingEpoch != terminalEpoch || stream.TerminalEpoch != terminalEpoch {
+		stream.mu.Unlock()
+		return
+	}
+	delete(stream.PendingTerminalDeliveries, strings.TrimSpace(subscriberID))
+	if !delivered {
+		stream.TerminalReplayRequired = true
+	}
+	subscriberCount := len(stream.Subscribers)
+	pendingCount := len(stream.PendingTerminalDeliveries)
+	replayRequired := stream.TerminalReplayRequired
+	stream.UpdatedAt = time.Now().UTC()
+	stream.mu.Unlock()
+	if subscriberCount != 0 || pendingCount != 0 {
+		return
+	}
+	if replayRequired {
+		broker.scheduleTerminalCleanupForStream(requestID, instanceID)
+	} else {
+		broker.removeIfIdleForStream(requestID, instanceID)
+	}
+}
+
 // Complete 把活动流标记为成功完成，并发布一个成功 endstream 事件。
 func (broker *StreamBroker) Complete(requestID string, terminalCode string, terminalMessage string) error {
 	stream, ok := broker.Get(requestID)
 	if !ok || stream == nil {
 		return fmt.Errorf("request is not active: %s", strings.TrimSpace(requestID))
 	}
-	stream.mu.Lock()
-	if stream.Status == StreamStatusCanceled || stream.Status == StreamStatusFailed || stream.Status == StreamStatusCompleted {
-		stream.mu.Unlock()
-		return nil
-	}
-	broker.stopTerminalCleanupTimerLocked(stream)
-	stream.Status = StreamStatusCompleted
-	subscriberCount := len(stream.Subscribers)
-	stream.UpdatedAt = time.Now().UTC()
-	stream.mu.Unlock()
-	if err := broker.Publish(requestID, StreamEvent{
+	return broker.CompleteStream(stream, terminalCode, terminalMessage)
+}
+
+func (broker *StreamBroker) CompleteStream(stream *ActiveStream, terminalCode string, terminalMessage string) error {
+	return broker.finishStream(stream, StreamStatusCompleted, StreamEvent{
 		End:                  true,
 		TerminalErrorCode:    strings.TrimSpace(terminalCode),
 		TerminalErrorMessage: strings.TrimSpace(terminalMessage),
-	}); err != nil {
-		return err
-	}
-	if subscriberCount == 0 {
-		broker.scheduleTerminalCleanup(requestID)
-	}
-	return nil
+	}, nil, false)
 }
 
 // Fail 把活动流标记为失败，并发布一个失败 endstream 事件。
@@ -382,23 +473,16 @@ func (broker *StreamBroker) Fail(requestID string, terminalCode string, terminal
 	if !ok || stream == nil {
 		return fmt.Errorf("request is not active: %s", strings.TrimSpace(requestID))
 	}
-	stream.mu.Lock()
-	broker.stopTerminalCleanupTimerLocked(stream)
-	stream.Status = StreamStatusFailed
-	subscriberCount := len(stream.Subscribers)
-	stream.UpdatedAt = time.Now().UTC()
-	stream.mu.Unlock()
-	if err := broker.Publish(requestID, StreamEvent{
+	return broker.FailStream(stream, terminalCode, terminalMessage)
+}
+
+func (broker *StreamBroker) FailStream(stream *ActiveStream, terminalCode string, terminalMessage string) error {
+	cause := fmt.Errorf("stream failed: %s", firstNonEmpty(strings.TrimSpace(terminalMessage), strings.TrimSpace(terminalCode), "unknown"))
+	return broker.finishStream(stream, StreamStatusFailed, StreamEvent{
 		End:                  true,
 		TerminalErrorCode:    strings.TrimSpace(terminalCode),
 		TerminalErrorMessage: strings.TrimSpace(terminalMessage),
-	}); err != nil {
-		return err
-	}
-	if subscriberCount == 0 {
-		broker.scheduleTerminalCleanup(requestID)
-	}
-	return nil
+	}, cause, false)
 }
 
 // Cancel 主动取消活动流，并发布 canceled endstream。
@@ -407,28 +491,86 @@ func (broker *StreamBroker) Cancel(requestID string, terminalMessage string) err
 	if !ok || stream == nil {
 		return fmt.Errorf("request is not active: %s", strings.TrimSpace(requestID))
 	}
+	return broker.CancelStream(stream, terminalMessage)
+}
+
+func (broker *StreamBroker) CancelStream(stream *ActiveStream, terminalMessage string) error {
+	message := firstNonEmpty(strings.TrimSpace(terminalMessage), "[canceled] User aborted request")
+	return broker.finishStream(stream, StreamStatusCanceled, StreamEvent{
+		End:                  true,
+		TerminalErrorCode:    "canceled",
+		TerminalErrorMessage: message,
+	}, fmt.Errorf("stream canceled: %s", message), true)
+}
+
+func (broker *StreamBroker) finishStream(stream *ActiveStream, status StreamStatus, event StreamEvent, waiterCause error, cancelProvider bool) error {
+	if stream == nil {
+		return fmt.Errorf("request stream is not available")
+	}
 	stream.mu.Lock()
+	if isTerminalStreamStatus(stream.Status) {
+		stream.mu.Unlock()
+		return nil
+	}
 	broker.stopTerminalCleanupTimerLocked(stream)
-	if stream.ProviderCancel != nil {
+	if cancelProvider && stream.ProviderCancel != nil {
 		stream.ProviderCancel()
 		stream.ProviderCancel = nil
 	}
-	stream.ProviderActive = false
-	stream.Status = StreamStatusCanceled
+	if cancelProvider {
+		stream.ProviderActive = false
+	}
+	stream.Status = status
+	stream.TerminalEpoch++
+	if stream.TerminalEpoch == 0 {
+		stream.TerminalEpoch++
+	}
+	event.End = true
+	event.TerminalEpoch = stream.TerminalEpoch
+	stream.PendingTerminalDeliveries = make(map[string]uint64)
+	stream.TerminalReplayRequired = false
+	if waiterCause != nil {
+		cancelStreamWaitersLocked(stream, waiterCause)
+	}
+	stream.Backlog = append(stream.Backlog, event)
 	subscriberCount := len(stream.Subscribers)
+	subscribers := make([]*StreamSubscriber, 0, subscriberCount)
+	for _, subscriber := range stream.Subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
 	stream.UpdatedAt = time.Now().UTC()
 	stream.mu.Unlock()
-	if err := broker.Publish(requestID, StreamEvent{
-		End:                  true,
-		TerminalErrorCode:    "canceled",
-		TerminalErrorMessage: firstNonEmpty(strings.TrimSpace(terminalMessage), "[canceled] User aborted request"),
-	}); err != nil {
-		return err
+	for _, subscriber := range subscribers {
+		if subscriber == nil {
+			continue
+		}
+		select {
+		case subscriber.Signal <- struct{}{}:
+		default:
+		}
 	}
 	if subscriberCount == 0 {
-		broker.scheduleTerminalCleanup(requestID)
+		broker.scheduleTerminalCleanupForStream(stream.RequestID, stream.InstanceID)
 	}
 	return nil
+}
+
+// cancelStreamWaitersLocked releases setup and KV barriers after terminal state.
+// The caller must hold stream.mu.
+func cancelStreamWaitersLocked(stream *ActiveStream, cause error) {
+	if stream == nil {
+		return
+	}
+	if stream.RunSetupActive {
+		stream.RunSetupCancelRequested = true
+	}
+	if stream.RunSetupCancel != nil {
+		stream.RunSetupCancel()
+	}
+	for id, pending := range stream.PendingKVAcks {
+		delete(stream.PendingKVAcks, id)
+		pending.complete(cause)
+	}
 }
 
 // firstNonEmpty 返回第一个非空白字符串。

--- a/internal/backend/forwarder/compaction.go
+++ b/internal/backend/forwarder/compaction.go
@@ -452,7 +452,7 @@ func (service *Service) handleCompactionEvent(stream *ActiveStream, payload *str
 		}); err != nil {
 			return service.failStream(stream, "unknown", err)
 		}
-		if err := service.broker.Complete(stream.RequestID, "", ""); err != nil {
+		if err := service.broker.CompleteStream(stream, "", ""); err != nil {
 			return service.failStream(stream, "unknown", err)
 		}
 		service.setTurnPhase(stream, TurnPhaseCompleted)
@@ -505,7 +505,7 @@ func (service *Service) finishManualCompactionNoop(stream *ActiveStream) error {
 	}); err != nil {
 		return err
 	}
-	return service.broker.Complete(stream.RequestID, "", "")
+	return service.broker.CompleteStream(stream, "", "")
 }
 
 func (service *Service) completeManualCompactionTurn(stream *ActiveStream) error {
@@ -1673,7 +1673,7 @@ func (service *Service) generateCompactionSummary(ctx context.Context, stream *A
 			if strings.TrimSpace(accumulated) == "" {
 				return nil
 			}
-			return service.broker.Publish(stream.RequestID, StreamEvent{
+			return service.broker.publishToStream(stream.RequestID, stream.InstanceID, StreamEvent{
 				Message: buildSummaryMessage(accumulated),
 			})
 		case modeladapter.ModelEventKindThinkingDelta, modeladapter.ModelEventKindThinkingCompleted:
@@ -1740,6 +1740,18 @@ func encodeConversationSummaryBytes(summary string) []byte {
 		return nil
 	}
 	payload, err := proto.Marshal(&agentv1.ConversationSummary{Summary: text})
+	if err != nil {
+		return nil
+	}
+	return payload
+}
+
+func encodeConversationSummaryArchiveBytes(summary string) []byte {
+	text := strings.TrimSpace(summary)
+	if text == "" {
+		return nil
+	}
+	payload, err := proto.Marshal(&agentv1.ConversationSummaryArchive{Summary: text})
 	if err != nil {
 		return nil
 	}

--- a/internal/backend/forwarder/history_maintenance.go
+++ b/internal/backend/forwarder/history_maintenance.go
@@ -47,9 +47,12 @@ func (service *Service) runHistoryMaintenance() error {
 			cleanupRootLegacyHistoryArtifact(historyRoot, entry.Name())
 			continue
 		}
+		if entry.Name() == conversationBlobDirectoryName {
+			continue
+		}
 		service.cleanupConversationLegacyArtifacts(filepath.Join(historyRoot, entry.Name()))
 	}
-	return nil
+	return service.pruneConversationBlobs()
 }
 
 func cleanupRootLegacyHistoryArtifact(historyRoot string, name string) {

--- a/internal/backend/forwarder/interaction_tools.go
+++ b/internal/backend/forwarder/interaction_tools.go
@@ -63,13 +63,16 @@ func (service *Service) handleInteractionResult(intent InboundIntent) error {
 	}
 	pending, found := selectPendingInteraction(intent.InteractionResponse, stream)
 	if !found {
+		if recentlyCompletedInteractionExists(stream, intent.InteractionResponse.GetId()) {
+			return nil
+		}
 		return fmt.Errorf("pending interaction not found")
 	}
 	result, err := service.interactionBridge.ApplyInteractionResponse(intent.InteractionResponse, pending)
 	if err != nil {
 		return err
 	}
-	markInteractionCompleted(stream, pending)
+	markInteractionCompleted(stream, pending, intent.InteractionResponse.GetId())
 	toolName := strings.TrimSpace(deriveToolNameFromPendingInteraction(pending))
 	if result.ToolCall != nil {
 		applySwitchModeMetadata(stream, result.ToolCall)
@@ -170,14 +173,44 @@ func switchModeTarget(args *agentv1.SwitchModeArgs) (agentv1.AgentMode, error) {
 	return parseTargetModeID(args.GetTargetModeId())
 }
 
-func markInteractionCompleted(stream *ActiveStream, pending runtimecore.PendingInteraction) {
+func markInteractionCompleted(stream *ActiveStream, pending runtimecore.PendingInteraction, messageID uint32) {
 	if stream == nil {
 		return
 	}
+	now := time.Now().UTC()
+	cutoff := now.Add(-completedClientResponseRetention)
 	stream.mu.Lock()
 	delete(stream.PendingInteractions, pending.InteractionID)
-	stream.UpdatedAt = time.Now().UTC()
+	if messageID != 0 {
+		if stream.RecentCompletedInteractions == nil {
+			stream.RecentCompletedInteractions = make(map[uint32]time.Time)
+		}
+		for id, completedAt := range stream.RecentCompletedInteractions {
+			if completedAt.Before(cutoff) {
+				delete(stream.RecentCompletedInteractions, id)
+			}
+		}
+		stream.RecentCompletedInteractions[messageID] = now
+	}
+	stream.UpdatedAt = now
 	stream.mu.Unlock()
+}
+
+func recentlyCompletedInteractionExists(stream *ActiveStream, messageID uint32) bool {
+	if stream == nil || messageID == 0 {
+		return false
+	}
+	now := time.Now().UTC()
+	cutoff := now.Add(-completedClientResponseRetention)
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	completedAt, ok := stream.RecentCompletedInteractions[messageID]
+	for id, timestamp := range stream.RecentCompletedInteractions {
+		if timestamp.Before(cutoff) {
+			delete(stream.RecentCompletedInteractions, id)
+		}
+	}
+	return ok && !completedAt.Before(cutoff)
 }
 
 func deriveToolNameFromPendingInteraction(pending runtimecore.PendingInteraction) string {

--- a/internal/backend/forwarder/legacy_stream.go
+++ b/internal/backend/forwarder/legacy_stream.go
@@ -17,18 +17,51 @@ const legacyRunSSEContentType = "text/event-stream"
 func NewLegacyRunSSEHandler(
 	procedure string,
 	implementation func(context.Context, *connect.Request[aiserverv1.BidiRequestId], *connect.ServerStream[agentv1.AgentServerMessage]) error,
+	onTerminalCompleted func(legacyRunSSETerminalCompletion, bool),
 	options ...connect.HandlerOption,
 ) http.Handler {
 	inner := connect.NewServerStreamHandler(procedure, implementation, options...)
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		inner.ServeHTTP(newLegacyRunSSEHeaderWriter(writer), request)
+		completion := &legacyRunSSECompletion{}
+		request = request.WithContext(context.WithValue(request.Context(), legacyRunSSECompletionContextKey{}, completion))
+		wrappedWriter := newLegacyRunSSEHeaderWriter(writer)
+		inner.ServeHTTP(wrappedWriter, request)
+		if completion.terminal && onTerminalCompleted != nil {
+			delivered := wrappedWriter.writeErr == nil && request.Context().Err() == nil
+			onTerminalCompleted(completion.delivery, delivered)
+		}
 	})
+}
+
+type legacyRunSSECompletionContextKey struct{}
+
+type legacyRunSSECompletion struct {
+	delivery legacyRunSSETerminalCompletion
+	terminal bool
+}
+
+type legacyRunSSETerminalCompletion struct {
+	requestID     string
+	instanceID    uint64
+	subscriberID  string
+	terminalEpoch uint64
+}
+
+func recordLegacyRunSSETerminal(ctx context.Context, delivery legacyRunSSETerminalCompletion) bool {
+	completion, _ := ctx.Value(legacyRunSSECompletionContextKey{}).(*legacyRunSSECompletion)
+	if completion == nil {
+		return false
+	}
+	completion.delivery = delivery
+	completion.terminal = true
+	return true
 }
 
 // legacyRunSSEHeaderWriter 在真正写出 header 时覆盖 Content-Type。
 type legacyRunSSEHeaderWriter struct {
 	http.ResponseWriter
 	wroteHeader bool
+	writeErr    error
 }
 
 // newLegacyRunSSEHeaderWriter 创建一个响应头包装器。
@@ -48,13 +81,17 @@ func (writer *legacyRunSSEHeaderWriter) Write(payload []byte) (int, error) {
 	if !writer.wroteHeader {
 		writer.WriteHeader(http.StatusOK)
 	}
-	return writer.ResponseWriter.Write(payload)
+	written, err := writer.ResponseWriter.Write(payload)
+	if err != nil && writer.writeErr == nil {
+		writer.writeErr = err
+	}
+	return written, err
 }
 
 // Flush 尝试把底层缓冲区立即刷新给客户端。
 func (writer *legacyRunSSEHeaderWriter) Flush() {
-	if flusher, ok := writer.ResponseWriter.(http.Flusher); ok {
-		flusher.Flush()
+	if err := http.NewResponseController(writer.ResponseWriter).Flush(); err != nil && writer.writeErr == nil {
+		writer.writeErr = err
 	}
 }
 

--- a/internal/backend/forwarder/module.go
+++ b/internal/backend/forwarder/module.go
@@ -10,12 +10,14 @@ import (
 )
 
 type Module struct {
-	Service                  *Service
-	LocalBidiHandler         http.Handler
-	LocalRunSSE              http.Handler
-	AiHandler                http.Handler
-	RepositoryServiceHandler http.Handler
-	UploadServiceHandler     http.Handler
+	Service                      *Service
+	LocalBidiHandler             http.Handler
+	LocalRunSSE                  http.Handler
+	LocalUploadConversationBlobs http.Handler
+	LocalNotifyConversationClone http.Handler
+	AiHandler                    http.Handler
+	RepositoryServiceHandler     http.Handler
+	UploadServiceHandler         http.Handler
 }
 
 // NewModule 创建 forwarder 模块，并导出本地 Bidi / RunSSE 处理器。
@@ -23,12 +25,32 @@ func NewModule(historyRoot string, channelService modeladapter.ChannelResolver) 
 	service := NewService(historyRoot, channelService)
 	legacyBidiAppendProcedure := "/aiserver.v1.BidiService/BidiAppend"
 	legacyRunSSEProcedure := "/agent.v1.AgentService/RunSSE"
+	uploadConversationBlobsProcedure := "/agent.v1.AgentService/UploadConversationBlobs"
+	notifyConversationCloneProcedure := "/agent.v1.AgentService/NotifyConversationClone"
 	return &Module{
-		Service:                  service,
-		LocalBidiHandler:         connect.NewUnaryHandler(legacyBidiAppendProcedure, service.BidiAppend),
-		LocalRunSSE:              NewLegacyRunSSEHandler(legacyRunSSEProcedure, service.RunSSE),
-		AiHandler:                newAIHandler(service),
-		RepositoryServiceHandler: newRepositoryServiceHandler(service),
-		UploadServiceHandler:     newUploadServiceHandler(service),
+		Service: service,
+		LocalBidiHandler: connect.NewUnaryHandler(
+			legacyBidiAppendProcedure,
+			service.BidiAppend,
+			connect.WithReadMaxBytes(conversationBidiMaxRequestBytes),
+		),
+		LocalRunSSE: NewLegacyRunSSEHandler(legacyRunSSEProcedure, service.RunSSE, func(completion legacyRunSSETerminalCompletion, delivered bool) {
+			service.broker.CompleteTerminalDelivery(
+				completion.requestID,
+				completion.instanceID,
+				completion.subscriberID,
+				completion.terminalEpoch,
+				delivered,
+			)
+		}),
+		LocalUploadConversationBlobs: connect.NewUnaryHandler(
+			uploadConversationBlobsProcedure,
+			service.UploadConversationBlobs,
+			connect.WithReadMaxBytes(conversationBlobMaxRequestBytes+(1<<20)),
+		),
+		LocalNotifyConversationClone: connect.NewUnaryHandler(notifyConversationCloneProcedure, service.NotifyConversationClone),
+		AiHandler:                    newAIHandler(service),
+		RepositoryServiceHandler:     newRepositoryServiceHandler(service),
+		UploadServiceHandler:         newUploadServiceHandler(service),
 	}
 }

--- a/internal/backend/forwarder/projector.go
+++ b/internal/backend/forwarder/projector.go
@@ -2,6 +2,7 @@
 package forwarder
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -17,6 +18,16 @@ import (
 const projectedConversationMaxTokens = 130000
 
 type HistoryProjector struct {
+}
+
+type CheckpointBlob struct {
+	ID   []byte
+	Data []byte
+}
+
+type LegacyCheckpointProjection struct {
+	State *agentv1.ConversationStateStructure
+	Blobs []CheckpointBlob
 }
 
 // NewHistoryProjector 创建 history 投影器。
@@ -481,7 +492,7 @@ func (projector *HistoryProjector) ProjectLegacyCheckpoint(conversation *Convers
 			MaxTokens:  conversationTokenDetailsMaxTokens(conversation),
 		},
 		Summary:          latestCompactionSummaryBytes(conversation),
-		SummaryArchive:   previousCompactionSummaryBytes(conversation),
+		SummaryArchive:   previousCompactionSummaryArchiveBytes(conversation),
 		SummaryArchives:  compactionSummaryArchives(conversation),
 		SelfSummaryCount: uint32(len(compactionSummaryTexts(conversation))),
 	}
@@ -688,6 +699,79 @@ func (projector *HistoryProjector) ProjectLegacyCheckpoint(conversation *Convers
 	return state, nil
 }
 
+// ProjectLegacyCheckpointWithBlobs 把 checkpoint 中的 bytes 实体转换成 Cursor 当前协议使用的 SHA-256 blob 引用。
+func (projector *HistoryProjector) ProjectLegacyCheckpointWithBlobs(conversation *ConversationFile) (*LegacyCheckpointProjection, error) {
+	state, err := projector.ProjectLegacyCheckpoint(conversation)
+	if err != nil {
+		return nil, err
+	}
+	return blobifyLegacyCheckpoint(state)
+}
+
+func blobifyLegacyCheckpoint(state *agentv1.ConversationStateStructure) (*LegacyCheckpointProjection, error) {
+	projection := &LegacyCheckpointProjection{State: state}
+	if state == nil {
+		projection.State = &agentv1.ConversationStateStructure{}
+		return projection, nil
+	}
+	seen := make(map[[sha256.Size]byte]struct{})
+	addBlob := func(data []byte) []byte {
+		if len(data) == 0 {
+			return nil
+		}
+		digest := sha256.Sum256(data)
+		if _, ok := seen[digest]; !ok {
+			seen[digest] = struct{}{}
+			projection.Blobs = append(projection.Blobs, CheckpointBlob{
+				ID:   append([]byte(nil), digest[:]...),
+				Data: append([]byte(nil), data...),
+			})
+		}
+		return append([]byte(nil), digest[:]...)
+	}
+	blobifyList := func(items [][]byte) [][]byte {
+		if len(items) == 0 {
+			return nil
+		}
+		result := make([][]byte, 0, len(items))
+		for _, item := range items {
+			if id := addBlob(item); len(id) > 0 {
+				result = append(result, id)
+			}
+		}
+		return result
+	}
+
+	state.RootPromptMessagesJson = blobifyList(state.GetRootPromptMessagesJson())
+	state.Todos = blobifyList(state.GetTodos())
+	state.SummaryArchives = blobifyList(state.GetSummaryArchives())
+	state.Summary = addBlob(state.GetSummary())
+	state.SummaryArchive = addBlob(state.GetSummaryArchive())
+	state.Plan = addBlob(state.GetPlan())
+
+	turnIDs := make([][]byte, 0, len(state.GetTurns()))
+	for _, rawTurn := range state.GetTurns() {
+		if len(rawTurn) == 0 {
+			continue
+		}
+		turn := &agentv1.ConversationTurnStructure{}
+		if err := proto.Unmarshal(rawTurn, turn); err != nil {
+			return nil, fmt.Errorf("decode projected turn for blob storage: %w", err)
+		}
+		if agentTurn := turn.GetAgentConversationTurn(); agentTurn != nil {
+			agentTurn.UserMessage = addBlob(agentTurn.GetUserMessage())
+			agentTurn.Steps = blobifyList(agentTurn.GetSteps())
+		}
+		encoded, err := proto.Marshal(turn)
+		if err != nil {
+			return nil, fmt.Errorf("encode projected turn for blob storage: %w", err)
+		}
+		turnIDs = append(turnIDs, addBlob(encoded))
+	}
+	state.Turns = turnIDs
+	return projection, nil
+}
+
 func marshalThinkingStep(text string) ([]byte, error) {
 	return proto.Marshal(&agentv1.ConversationStep{
 		Message: &agentv1.ConversationStep_ThinkingMessage{
@@ -718,12 +802,12 @@ func latestCompactionSummaryBytes(conversation *ConversationFile) []byte {
 	return encodeConversationSummaryBytes(texts[len(texts)-1])
 }
 
-func previousCompactionSummaryBytes(conversation *ConversationFile) []byte {
+func previousCompactionSummaryArchiveBytes(conversation *ConversationFile) []byte {
 	texts := compactionSummaryTexts(conversation)
 	if len(texts) < 2 {
 		return nil
 	}
-	return encodeConversationSummaryBytes(texts[len(texts)-2])
+	return encodeConversationSummaryArchiveBytes(texts[len(texts)-2])
 }
 
 func compactionSummaryArchives(conversation *ConversationFile) [][]byte {
@@ -733,7 +817,7 @@ func compactionSummaryArchives(conversation *ConversationFile) [][]byte {
 	}
 	archives := make([][]byte, 0, len(texts))
 	for _, text := range texts {
-		if encoded := encodeConversationSummaryBytes(text); len(encoded) > 0 {
+		if encoded := encodeConversationSummaryArchiveBytes(text); len(encoded) > 0 {
 			archives = append(archives, encoded)
 		}
 	}

--- a/internal/backend/forwarder/runtime_summary.go
+++ b/internal/backend/forwarder/runtime_summary.go
@@ -29,7 +29,7 @@ func newRuntimeConversation(conversationID string, mode agentv1.AgentMode) (*Con
 	}, nil
 }
 
-func (service *Service) bootstrapRuntimeConversation(intent InboundIntent) (*ConversationFile, agentv1.AgentMode, int64, []HistoryEntry, error) {
+func (service *Service) bootstrapRuntimeConversation(stream *ActiveStream, intent InboundIntent) (*ConversationFile, agentv1.AgentMode, int64, []HistoryEntry, error) {
 	if service == nil {
 		return nil, agentv1.AgentMode_AGENT_MODE_AGENT, 0, nil, fmt.Errorf("forwarder service is nil")
 	}
@@ -50,7 +50,7 @@ func (service *Service) bootstrapRuntimeConversation(intent InboundIntent) (*Con
 	}
 	importedEntries := []HistoryEntry(nil)
 	if len(conversation.Entries) == 0 && intent.ConversationState != nil {
-		importedEntries, err = service.importConversationState(conversation, intent.ConversationState)
+		importedEntries, err = service.importConversationState(intent.Context, stream, conversation, intent.ConversationState)
 		if err != nil {
 			return nil, agentv1.AgentMode_AGENT_MODE_AGENT, 0, nil, err
 		}

--- a/internal/backend/forwarder/service.go
+++ b/internal/backend/forwarder/service.go
@@ -3,12 +3,16 @@ package forwarder
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -28,12 +32,14 @@ import (
 )
 
 const (
-	providerResumeDebounce         = 200 * time.Millisecond
-	completedExecRetention         = 15 * time.Second
-	nonStreamingExecCloseGrace     = 1500 * time.Millisecond
-	defaultSummaryCompletedThought = "Chat context summarized"
-	providerDefaultMaxOutputTokens = 65536
-	providerOutputSafetyTokens     = 1024
+	providerResumeDebounce           = 200 * time.Millisecond
+	completedClientResponseRetention = appendSequenceRetention
+	nonStreamingExecCloseGrace       = 1500 * time.Millisecond
+	defaultSummaryCompletedThought   = "Chat context summarized"
+	providerDefaultMaxOutputTokens   = 65536
+	providerOutputSafetyTokens       = 1024
+	runIngressCancelWaitTimeout      = 5 * time.Second
+	runIngressCancelWaiterLimit      = 1024
 
 	runtimeThinkingEffortParameterID = "thinking_effort"
 )
@@ -245,22 +251,89 @@ func subagentModelOverrideSummaries(overrides map[string]runtimecore.SubagentMod
 }
 
 type Service struct {
-	store              *ConversationFileStore
-	usageStore         *UsageFileStore
-	codebaseIndexStore *CodebaseIndexStore
-	docsIndexStore     *DocsIndexStore
-	rules              *UserRuleStore
-	projector          *HistoryProjector
-	compiler           PromptCompiler
-	provider           ProviderGateway
-	resolver           modeladapter.ChannelResolver
-	modelMemory        agentModelMemory
-	broker             *StreamBroker
-	recorder           *artifactRecorder
-	debug              *debugRecorder
-	execBridge         execbridge.ExecBridge
-	interactionBridge  interactionbridge.InteractionBridge
-	appendSeq          *appendSequenceTracker
+	store                   *ConversationFileStore
+	blobStore               *ConversationBlobStore
+	usageStore              *UsageFileStore
+	codebaseIndexStore      *CodebaseIndexStore
+	docsIndexStore          *DocsIndexStore
+	rules                   *UserRuleStore
+	projector               *HistoryProjector
+	compiler                PromptCompiler
+	provider                ProviderGateway
+	resolver                modeladapter.ChannelResolver
+	modelMemory             agentModelMemory
+	broker                  *StreamBroker
+	recorder                *artifactRecorder
+	debug                   *debugRecorder
+	execBridge              execbridge.ExecBridge
+	interactionBridge       interactionbridge.InteractionBridge
+	appendSeq               *appendSequenceTracker
+	nextKVMessageID         atomic.Uint32
+	nextRunIngressID        atomic.Uint64
+	blobMaintenanceMu       sync.Mutex
+	kvAckMu                 sync.Mutex
+	kvAckRoutes             map[uint32]kvAckRoute
+	runSetupMu              sync.Mutex
+	runIngresses            map[string]map[uint64]*runIngressState
+	runIngressChanged       chan struct{}
+	pendingRunCancelWaiters map[string]map[*runIngressCancelWaiter]struct{}
+	pendingRunCancelCount   int
+}
+
+type runIngressState struct {
+	ticketAcquired   bool
+	ticketFinalized  bool
+	appendGeneration appendSequenceGeneration
+	cancelRequested  bool
+	cancelWaiters    map[*runIngressCancelWaiter]struct{}
+	setupStream      *ActiveStream
+	setupGeneration  uint64
+}
+
+type runIngressCancelWaiter struct {
+	appendSeq   int64
+	fingerprint [sha256.Size]byte
+	done        chan struct{}
+	once        sync.Once
+	active      bool
+	targets     map[uint64]struct{}
+	err         error
+}
+
+type kvAckRoute struct {
+	requestID        string
+	stream           *ActiveStream
+	streamInstanceID uint64
+	kind             pendingKVOperation
+	appendGeneration appendSequenceGeneration
+	appendSequences  map[kvAckAppendSequenceKey]appendSequenceGeneration
+	restartDone      chan struct{}
+	completed        bool
+	createdAt        time.Time
+}
+
+type kvAckAppendSequenceKey struct {
+	appendSeq   int64
+	fingerprint [sha256.Size]byte
+}
+
+type kvAckRestartToken struct {
+	requestID        string
+	streamInstanceID uint64
+	appendGeneration appendSequenceGeneration
+	done             chan struct{}
+}
+
+type runIngressCancelBinding struct {
+	bound             bool
+	waiting           bool
+	completeAppend    bool
+	appendGeneration  appendSequenceGeneration
+	requestID         string
+	ingressGeneration uint64
+	setupGeneration   uint64
+	setupCancel       context.CancelFunc
+	stream            *ActiveStream
 }
 
 type agentModelMemory interface {
@@ -284,22 +357,26 @@ func NewService(historyRoot string, resolver modeladapter.ChannelResolver) *Serv
 	}
 	debug := newDebugRecorder(historyRoot, broker, debugConfig)
 	service := &Service{
-		store:              store,
-		usageStore:         NewUsageFileStore(historyRoot),
-		codebaseIndexStore: NewCodebaseIndexStore(appdata.CodebaseIndexRootPath()),
-		docsIndexStore:     NewDocsIndexStore(appdata.DocsIndexRootPath()),
-		rules:              rules,
-		projector:          projector,
-		compiler:           NewPromptCompiler(projector, NewToolCatalog(), NewReminderInjector(), rules),
-		provider:           NewProviderGateway(resolver),
-		resolver:           resolver,
-		modelMemory:        modelMemory,
-		broker:             broker,
-		recorder:           newArtifactRecorder(store, broker, debug),
-		debug:              debug,
-		execBridge:         execbridge.NewBridge(),
-		interactionBridge:  interactionbridge.NewBridge(),
-		appendSeq:          newAppendSequenceTracker(),
+		store:                   store,
+		blobStore:               NewConversationBlobStore(historyRoot),
+		usageStore:              NewUsageFileStore(historyRoot),
+		codebaseIndexStore:      NewCodebaseIndexStore(appdata.CodebaseIndexRootPath()),
+		docsIndexStore:          NewDocsIndexStore(appdata.DocsIndexRootPath()),
+		rules:                   rules,
+		projector:               projector,
+		compiler:                NewPromptCompiler(projector, NewToolCatalog(), NewReminderInjector(), rules),
+		provider:                NewProviderGateway(resolver),
+		resolver:                resolver,
+		modelMemory:             modelMemory,
+		broker:                  broker,
+		recorder:                newArtifactRecorder(store, broker, debug),
+		debug:                   debug,
+		execBridge:              execbridge.NewBridge(),
+		interactionBridge:       interactionbridge.NewBridge(),
+		appendSeq:               newAppendSequenceTracker(),
+		runIngresses:            make(map[string]map[uint64]*runIngressState),
+		runIngressChanged:       make(chan struct{}),
+		pendingRunCancelWaiters: make(map[string]map[*runIngressCancelWaiter]struct{}),
 	}
 	service.startHistoryMaintenance()
 	return service
@@ -313,20 +390,24 @@ func newServiceWithDependencies(store *ConversationFileStore, projector *History
 	}
 	debug := newDebugRecorder(historyRoot, broker, nil)
 	return &Service{
-		store:              store,
-		rules:              NewUserRuleStore(appdata.RulesRootPath()),
-		projector:          projector,
-		compiler:           compiler,
-		provider:           provider,
-		broker:             broker,
-		usageStore:         NewUsageFileStore(store.HistoryDir()),
-		codebaseIndexStore: NewCodebaseIndexStore(appdata.CodebaseIndexRootPath()),
-		docsIndexStore:     NewDocsIndexStore(appdata.DocsIndexRootPath()),
-		recorder:           newArtifactRecorder(store, broker, debug),
-		debug:              debug,
-		execBridge:         execbridge.NewBridge(),
-		interactionBridge:  interactionbridge.NewBridge(),
-		appendSeq:          newAppendSequenceTracker(),
+		store:                   store,
+		blobStore:               NewConversationBlobStore(historyRoot),
+		rules:                   NewUserRuleStore(appdata.RulesRootPath()),
+		projector:               projector,
+		compiler:                compiler,
+		provider:                provider,
+		broker:                  broker,
+		usageStore:              NewUsageFileStore(store.HistoryDir()),
+		codebaseIndexStore:      NewCodebaseIndexStore(appdata.CodebaseIndexRootPath()),
+		docsIndexStore:          NewDocsIndexStore(appdata.DocsIndexRootPath()),
+		recorder:                newArtifactRecorder(store, broker, debug),
+		debug:                   debug,
+		execBridge:              execbridge.NewBridge(),
+		interactionBridge:       interactionbridge.NewBridge(),
+		appendSeq:               newAppendSequenceTracker(),
+		runIngresses:            make(map[string]map[uint64]*runIngressState),
+		runIngressChanged:       make(chan struct{}),
+		pendingRunCancelWaiters: make(map[string]map[*runIngressCancelWaiter]struct{}),
 	}
 }
 
@@ -341,22 +422,227 @@ func (service *Service) BidiAppend(ctx context.Context, req *connect.Request[ais
 	}
 	appendSeqno := req.Msg.GetAppendSeqno()
 	dataHex := req.Msg.GetData()
-	appendTicket, staleAppend, err := service.appendSeq.Acquire(ctx, requestID, appendSeqno)
+	dataBinary := req.Msg.GetDataBinary()
+	message, clientKind, rawData, decodeErr := protocol.DecodeAgentClientMessagePayload(dataHex, dataBinary)
+	if len(dataBinary) > 0 {
+		dataHex = hex.EncodeToString(dataBinary)
+	}
+	isRunIngress := decodeErr == nil && isRunIngressClientMessage(message, clientKind)
+	isCancel := decodeErr == nil && isConversationCancelMessage(message)
+	var kvMessage *agentv1.KvClientMessage
+	if decodeErr == nil {
+		kvMessage = message.GetKvClientMessage()
+	}
+	var appendFingerprint [sha256.Size]byte
+	if decodeErr == nil {
+		appendFingerprint = sha256.Sum256(rawData)
+	}
+	allowSequenceRestart := service.allowAppendSequenceRestart(requestID, appendSeqno, message, clientKind, appendFingerprint)
+	var kvRestart kvAckRestartToken
+	if kvMessage != nil && appendSeqno == 0 && allowSequenceRestart {
+		kvRestart = service.beginKVAckSequenceRestart(requestID, kvMessage)
+	}
+	var cancelBinding runIngressCancelBinding
+	if isCancel {
+		cancelBinding = service.bindCancelToRunIngress(requestID, appendSeqno)
+		if appendSeqno == 0 && !cancelBinding.bound {
+			cancelBinding = service.bindCancelToActiveStream(requestID)
+		}
+	}
+	if isCancel && appendSeqno == 0 && !cancelBinding.bound {
+		service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+			"client_kind": strings.TrimSpace(clientKind),
+			"reason":      "unbound_sequence_zero_cancel",
+		})
+		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+	}
+	if isCancel && appendSeqno > 0 && !cancelBinding.bound && cancelBinding.waiting {
+		var waitErr error
+		cancelBinding, waitErr = service.waitForRunIngressCancelBinding(ctx, requestID, appendSeqno, appendFingerprint)
+		if waitErr != nil {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "deferred", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "run_ingress_cancel_wait_failed",
+				"error":       waitErr.Error(),
+			})
+			code := connect.CodeUnavailable
+			if errors.Is(waitErr, context.Canceled) || errors.Is(waitErr, context.DeadlineExceeded) && ctx.Err() != nil {
+				code = connect.CodeCanceled
+			}
+			return nil, connect.NewError(code, waitErr)
+		}
+	}
+	if isCancel && appendSeqno > 0 && !cancelBinding.bound && !service.hasCancelableStreamLifecycle(requestID) {
+		waitErr := fmt.Errorf("run lifecycle is not ready for cancellation")
+		service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "deferred", map[string]any{
+			"client_kind": strings.TrimSpace(clientKind),
+			"reason":      "cancel_arrived_before_run_lifecycle",
+			"error":       waitErr.Error(),
+		})
+		return nil, connect.NewError(connect.CodeUnavailable, waitErr)
+	}
+	if isCancel && cancelBinding.bound {
+		if appendSeqno > 0 {
+			if cancelBinding.completeAppend {
+				generationMatched, completion := service.completeAppendAheadForGeneration(requestID, appendSeqno, cancelBinding.appendGeneration, appendFingerprint)
+				if !generationMatched {
+					return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("run lifecycle changed before cancellation could be sequenced"))
+				}
+				if completion.retry {
+					return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("append replay prefix is not ready for cancellation"))
+				}
+				if completion.stale {
+					service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+						"client_kind": strings.TrimSpace(clientKind),
+						"reason":      "duplicate_cancel_append",
+					})
+					return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+				}
+			}
+		} else {
+			allowSequenceRestart = true
+			cancelRestart := service.beginKVAckSequenceRestartForGeneration(requestID, service.appendSeq.CaptureGeneration(requestID))
+			appendTicket, staleCancel, acquireErr := service.appendSeq.AcquireForTransportWithFingerprint(ctx, requestID, appendSeqno, allowSequenceRestart, appendFingerprint)
+			if acquireErr != nil {
+				service.abortKVAckSequenceRestart(cancelRestart)
+				return nil, connect.NewError(connect.CodeCanceled, acquireErr)
+			}
+			if staleCancel {
+				service.abortKVAckSequenceRestart(cancelRestart)
+				service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+					"client_kind": strings.TrimSpace(clientKind),
+					"reason":      "duplicate_cancel_append",
+				})
+				return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+			}
+			service.finishAppendSequenceReplayRestart(cancelRestart, appendTicket)
+			defer appendTicket.Release()
+		}
+		intent, err := service.decodeInboundIntent(requestID, message, clientKind)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		intent.Context = ctx
+		service.dispatchRunIngressCancel(cancelBinding, intent)
+		service.debug.LogBidiRaw(ctx, requestID, intent.ConversationID, appendSeqno, dataHex, "accepted", map[string]any{
+			"client_kind": strings.TrimSpace(clientKind),
+		})
+		service.debug.LogBidiDecoded(ctx, requestID, intent.ConversationID, appendSeqno, clientKind, message, intent, nil)
+		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+	}
+	if decodeErr == nil && appendSeqno == 0 && !allowSequenceRestart {
+		log.Printf("forwarder ignored lifecycle-mismatched bidi append request_id=%s append_seqno=0 kind=%s", requestID, strings.TrimSpace(clientKind))
+		service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+			"client_kind": strings.TrimSpace(clientKind),
+			"reason":      "sequence_zero_lifecycle_mismatch",
+		})
+		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+	}
+	var runIngressGeneration uint64
+	if isRunIngress &&
+		!service.appendSeq.IsDefinitelyStale(requestID, appendSeqno, allowSequenceRestart) {
+		runIngressGeneration = service.beginRunIngress(requestID)
+		defer service.endRunIngress(requestID, runIngressGeneration)
+	}
+	if kvMessage != nil && appendSeqno > 0 {
+		if !service.trackKVAckAppendSequence(requestID, kvMessage, appendSeqno, appendFingerprint) {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "unmatched_kv_result",
+			})
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+		generationMatched, completion := service.completeTrackedKVAckAppendSequence(requestID, kvMessage.GetId(), appendSeqno, appendFingerprint)
+		if !generationMatched {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "kv_lifecycle_mismatch",
+			})
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+		if completion.retry {
+			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("append replay prefix is not ready for KV completion"))
+		}
+		if completion.stale {
+			log.Printf("forwarder ignored stale bidi append request_id=%s append_seqno=%d", requestID, appendSeqno)
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", nil)
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+		_, matched := service.acknowledgeKVClientMessage(requestID, kvMessage)
+		if !matched {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "unmatched_kv_result",
+			})
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+		intent, err := service.decodeInboundIntent(requestID, message, clientKind)
+		if err != nil {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "intent_error", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"error":       err.Error(),
+			})
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		intent.Context = ctx
+		service.debug.LogBidiRaw(ctx, requestID, intent.ConversationID, appendSeqno, dataHex, "accepted", map[string]any{
+			"client_kind": strings.TrimSpace(clientKind),
+		})
+		service.debug.LogBidiDecoded(ctx, requestID, intent.ConversationID, appendSeqno, clientKind, message, intent, nil)
+		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+	}
+	var appendTicket appendSequenceTicket
+	var staleAppend bool
+	var err error
+	var replayRestart kvAckRestartToken
+	if decodeErr == nil {
+		replayRestart = service.beginAppendSequenceReplayRestart(requestID, appendSeqno, appendFingerprint)
+		if replayRestart.done == nil && appendSeqno == 0 && allowSequenceRestart && kvMessage == nil && !isRunIngress {
+			replayRestart = service.beginKVAckSequenceRestartForGeneration(requestID, service.appendSeq.CaptureGeneration(requestID))
+		}
+		appendTicket, staleAppend, err = service.appendSeq.AcquireForTransportWithFingerprint(ctx, requestID, appendSeqno, allowSequenceRestart, appendFingerprint)
+	} else {
+		appendTicket, staleAppend, err = service.appendSeq.AcquireForTransport(ctx, requestID, appendSeqno, allowSequenceRestart)
+	}
 	if err != nil {
+		service.abortKVAckSequenceRestart(replayRestart)
 		return nil, connect.NewError(connect.CodeCanceled, err)
 	}
 	if staleAppend {
+		service.abortKVAckSequenceRestart(replayRestart)
 		log.Printf("forwarder ignored stale bidi append request_id=%s append_seqno=%d", requestID, appendSeqno)
 		service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", nil)
 		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
 	}
-	defer appendTicket.Release()
-	message, clientKind, err := protocol.DecodeAgentClientMessage(dataHex)
-	if err != nil {
+	service.finishAppendSequenceReplayRestart(replayRestart, appendTicket)
+	if runIngressGeneration != 0 {
+		service.acquireRunIngressTicket(requestID, runIngressGeneration, appendTicket)
+		defer service.finishRunIngressTicket(requestID, runIngressGeneration, appendTicket)
+	} else {
+		defer appendTicket.Release()
+	}
+	if kvMessage != nil && appendSeqno == 0 {
+		generation := appendTicket.Generation()
+		if !service.adoptKVAckSequenceRestart(kvRestart, generation) {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "kv_restart_adoption_failed",
+			})
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+		if _, matched := service.acknowledgeKVClientMessage(requestID, kvMessage); !matched {
+			service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "stale", map[string]any{
+				"client_kind": strings.TrimSpace(clientKind),
+				"reason":      "unmatched_kv_result",
+			})
+			return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+		}
+	}
+	if decodeErr != nil {
 		service.debug.LogBidiRaw(ctx, requestID, "", appendSeqno, dataHex, "decode_error", map[string]any{
-			"error": err.Error(),
+			"error": decodeErr.Error(),
 		})
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, connect.NewError(connect.CodeInvalidArgument, decodeErr)
 	}
 	intent, err := service.decodeInboundIntent(requestID, message, clientKind)
 	if err != nil {
@@ -369,10 +655,15 @@ func (service *Service) BidiAppend(ctx context.Context, req *connect.Request[ais
 		})
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	intent.Context = ctx
+	intent.RunIngressGeneration = runIngressGeneration
 	service.debug.LogBidiRaw(ctx, requestID, intent.ConversationID, appendSeqno, dataHex, "accepted", map[string]any{
 		"client_kind": strings.TrimSpace(clientKind),
 	})
 	service.debug.LogBidiDecoded(ctx, requestID, intent.ConversationID, appendSeqno, clientKind, message, intent, nil)
+	if strings.TrimSpace(intent.Kind) == "kv_result" {
+		return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+	}
 	if err := service.dispatchInboundIntent(intent); err != nil {
 		if shouldAcknowledgeInterruptedInboundIntent(intent, err) {
 			service.debug.LogRuntime(ctx, requestID, intent.ConversationID, "dispatch_interrupted_ignored", map[string]any{
@@ -387,7 +678,11 @@ func (service *Service) BidiAppend(ctx context.Context, req *connect.Request[ais
 		})
 		code := connect.CodeInvalidArgument
 		if strings.TrimSpace(intent.Kind) == "run" {
-			code = connect.CodeInternal
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				code = connect.CodeCanceled
+			} else {
+				code = connect.CodeInternal
+			}
 		}
 		return nil, connect.NewError(code, err)
 	}
@@ -399,6 +694,67 @@ func (service *Service) BidiAppend(ctx context.Context, req *connect.Request[ais
 	})
 
 	return connect.NewResponse(&aiserverv1.BidiAppendResponse{}), nil
+}
+
+func isConversationCancelMessage(message *agentv1.AgentClientMessage) bool {
+	return message != nil && message.GetConversationAction().GetCancelAction() != nil
+}
+
+func isRunIngressClientMessage(message *agentv1.AgentClientMessage, clientKind string) bool {
+	switch strings.TrimSpace(clientKind) {
+	case "run_request", "prewarm_request":
+		return true
+	case "conversation_action":
+		return message != nil && conversationActionStartsRun(message.GetConversationAction())
+	default:
+		return false
+	}
+}
+
+func (service *Service) allowAppendSequenceRestart(requestID string, appendSeqno int64, message *agentv1.AgentClientMessage, clientKind string, sequenceZeroFingerprint [sha256.Size]byte) bool {
+	if service == nil || service.broker == nil || appendSeqno != 0 || message == nil || strings.TrimSpace(clientKind) == "" {
+		return false
+	}
+	if !service.appendSeq.ObserveSequenceZeroFingerprint(requestID, sequenceZeroFingerprint) {
+		return false
+	}
+	if strings.TrimSpace(clientKind) == "kv_client_message" {
+		return service.kvAckMessageMatches(requestID, message.GetKvClientMessage())
+	}
+	stream, ok := service.broker.Get(requestID)
+	if !ok || stream == nil {
+		return isRunIngressClientMessage(message, clientKind)
+	}
+	stream.mu.Lock()
+	terminal := isTerminalStreamStatus(stream.Status) || stream.Phase == TurnPhaseCanceled || stream.Phase == TurnPhaseCompleted || stream.Phase == TurnPhaseFailed
+	placeholder := !terminal && stream.Status == StreamStatusCreated && strings.TrimSpace(stream.ConversationID) == "" && !stream.RunSetupActive && !stream.ProviderActive
+	stream.mu.Unlock()
+	if isRunIngressClientMessage(message, clientKind) {
+		return placeholder || terminal
+	}
+	switch strings.TrimSpace(clientKind) {
+	case "exec_client_message":
+		item := message.GetExecClientMessage()
+		if item == nil {
+			return false
+		}
+		_, found := selectPendingExec(item.GetExecId(), item.GetId(), stream)
+		return found || recentlyCompletedExecExists(stream, item.GetId())
+	case "exec_client_control_message":
+		control := message.GetExecClientControlMessage()
+		_, found := selectPendingExecByControl(control, stream)
+		if found {
+			return true
+		}
+		messageID, valid := execControlMessageID(control)
+		return valid && recentlyCompletedExecExists(stream, messageID)
+	case "interaction_response":
+		response := message.GetInteractionResponse()
+		_, found := selectPendingInteraction(response, stream)
+		return found || recentlyCompletedInteractionExists(stream, response.GetId())
+	default:
+		return false
+	}
 }
 
 func shouldAcknowledgeInterruptedInboundIntent(intent InboundIntent, err error) bool {
@@ -422,20 +778,31 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 	if requestID == "" {
 		return buildRunSSECustomError(connect.CodeInvalidArgument, "请求参数无效", fmt.Errorf("request_id is required"))
 	}
-	subscriberID, signal, err := service.broker.Subscribe(requestID)
+	activeStream, subscriberID, signal, err := service.broker.Subscribe(requestID)
 	if err != nil {
 		return buildRunSSECustomError(connect.CodeInvalidArgument, "请求参数无效", err)
 	}
 	service.debug.LogRunSSE(ctx, requestID, "", "subscribe", map[string]any{
 		"subscriber_id": subscriberID,
 	})
+	terminalObserved := false
+	completionRegistered := false
+	var terminalEpoch uint64
 	defer func() {
-		remaining := service.broker.Unsubscribe(requestID, subscriberID)
+		result := service.broker.Unsubscribe(activeStream, subscriberID, terminalObserved, completionRegistered, terminalEpoch)
 		service.debug.LogRunSSE(context.Background(), requestID, "", "unsubscribe", map[string]any{
 			"subscriber_id":         subscriberID,
-			"remaining_subscribers": remaining,
+			"remaining_subscribers": result.Remaining,
 		})
-		if remaining == 0 {
+		if result.Remaining == 0 {
+			if result.Terminal {
+				if result.Retain {
+					service.broker.scheduleTerminalCleanupForStream(requestID, activeStream.InstanceID)
+				} else {
+					service.broker.removeIfIdleForStream(requestID, activeStream.InstanceID)
+				}
+				return
+			}
 			// RunSSE 连接短暂抖动时，给活跃 provider 一段重连宽限期，
 			// 避免把本来还能正常收口的请求直接打成 context canceled。
 			if !service.scheduleOrphanCancelActor(requestID, "[canceled] RunSSE client disconnected") {
@@ -447,8 +814,12 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	cursor := 0
+	deliveredBlobIDs := make(map[[32]byte]struct{})
+	blobDeliveryDeadlines := make(map[int]time.Time)
+	blobDeliveryFailures := 0
+	var blobDeliveryRetryAt time.Time
 	for {
-		backlog, err := service.broker.ReadFromCursor(requestID, cursor)
+		backlog, err := service.broker.ReadFromStreamCursor(activeStream, cursor)
 		if err != nil {
 			service.debug.LogRunSSE(ctx, requestID, "", "read_error", map[string]any{
 				"cursor": cursor,
@@ -457,21 +828,84 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 			return nil
 		}
 		if len(backlog) > 0 {
+			retryRequiredCheckpoint := false
 			for _, event := range backlog {
-				if event.Message != nil {
-					if err := stream.Send(event.Message); err != nil {
+				message := event.Message
+				if len(event.CheckpointBlobIDs) > 0 {
+					deliveryDeadline := time.Time{}
+					if event.RequireBlobDelivery {
+						deliveryDeadline = blobDeliveryDeadlines[cursor]
+						if deliveryDeadline.IsZero() {
+							deliveryDeadline = time.Now().Add(conversationBlobAckBatchTimeout)
+							blobDeliveryDeadlines[cursor] = deliveryDeadline
+						}
+					}
+					if time.Now().Before(blobDeliveryRetryAt) {
+						service.debug.LogRunSSE(ctx, requestID, "", "checkpoint_blob_backoff", map[string]any{
+							"cursor":   cursor,
+							"retry_at": blobDeliveryRetryAt.UTC().Format(time.RFC3339Nano),
+						})
+						if event.RequireBlobDelivery {
+							retryRequiredCheckpoint = true
+						} else {
+							message = nil
+						}
+					} else if blobCount, err := service.deliverCheckpointBlobs(ctx, deliveryDeadline, activeStream, event.CheckpointBlobIDs, deliveredBlobIDs, stream.Send); err != nil {
+						if ctx.Err() != nil {
+							return nil
+						}
+						var sendErr *checkpointBlobSendError
+						if errors.As(err, &sendErr) {
+							service.debug.LogRunSSE(ctx, requestID, "", "send_error", map[string]any{
+								"cursor":       cursor,
+								"message_case": "kvServerMessage",
+								"error":        sendErr.Error(),
+							})
+							return sendErr.Unwrap()
+						}
+						service.debug.LogRunSSE(ctx, requestID, "", "checkpoint_blob_error", map[string]any{
+							"cursor":     cursor,
+							"blob_count": blobCount,
+							"error":      err.Error(),
+						})
+						if service.checkpointBlobDeliveryAborted(activeStream) {
+							blobDeliveryFailures = 0
+							blobDeliveryRetryAt = time.Time{}
+							message = nil
+						} else {
+							blobDeliveryFailures++
+							blobDeliveryRetryAt = time.Now().Add(checkpointBlobRetryDelay(blobDeliveryFailures))
+							if event.RequireBlobDelivery {
+								if deliveryDeadline.IsZero() || !time.Now().Before(deliveryDeadline) || !blobDeliveryRetryAt.Before(deliveryDeadline) {
+									return connect.NewError(connect.CodeUnavailable, fmt.Errorf("deliver required conversation checkpoint: %w", err))
+								}
+								retryRequiredCheckpoint = true
+							} else {
+								message = nil
+							}
+						}
+					} else {
+						blobDeliveryFailures = 0
+						blobDeliveryRetryAt = time.Time{}
+					}
+				}
+				if retryRequiredCheckpoint {
+					break
+				}
+				if message != nil {
+					if err := stream.Send(message); err != nil {
 						service.debug.LogRunSSE(ctx, requestID, "", "send_error", map[string]any{
 							"cursor":       cursor,
-							"message_case": agentServerMessageCase(event.Message),
-							"message":      protoJSONDebugPayload(event.Message),
+							"message_case": agentServerMessageCase(message),
+							"message":      protoJSONDebugPayload(message),
 							"error":        err.Error(),
 						})
 						return err
 					}
 					service.debug.LogRunSSE(ctx, requestID, "", "send_message", map[string]any{
 						"cursor":       cursor,
-						"message_case": agentServerMessageCase(event.Message),
-						"message":      protoJSONDebugPayload(event.Message),
+						"message_case": agentServerMessageCase(message),
+						"message":      protoJSONDebugPayload(message),
 					})
 				}
 				cursor++
@@ -481,7 +915,20 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 						"terminal_error_code":    strings.TrimSpace(event.TerminalErrorCode),
 						"terminal_error_message": strings.TrimSpace(event.TerminalErrorMessage),
 					})
+					terminalObserved = true
+					terminalEpoch = event.TerminalEpoch
+					completionRegistered = recordLegacyRunSSETerminal(ctx, legacyRunSSETerminalCompletion{
+						requestID:     requestID,
+						instanceID:    activeStream.InstanceID,
+						subscriberID:  subscriberID,
+						terminalEpoch: terminalEpoch,
+					})
 					return buildTerminalStreamError(event)
+				}
+			}
+			if retryRequiredCheckpoint {
+				if err := service.waitForCheckpointBlobRetry(ctx, signal, activeStream, blobDeliveryRetryAt); err != nil {
+					return nil
 				}
 			}
 			continue
@@ -492,7 +939,7 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 				"cursor": cursor,
 				"error":  ctx.Err().Error(),
 			})
-			if backlog, err := service.broker.ReadFromCursor(requestID, cursor); err == nil {
+			if backlog, err := service.broker.ReadFromStreamCursor(activeStream, cursor); err == nil {
 				for _, event := range backlog {
 					cursor++
 					if event.End {
@@ -510,7 +957,7 @@ func (service *Service) RunSSE(ctx context.Context, req *connect.Request[aiserve
 			continue
 		case <-ticker.C:
 		}
-		if backlog, err := service.broker.ReadFromCursor(requestID, cursor); err != nil {
+		if backlog, err := service.broker.ReadFromStreamCursor(activeStream, cursor); err != nil {
 			service.debug.LogRunSSE(ctx, requestID, "", "read_error", map[string]any{
 				"cursor": cursor,
 				"error":  err.Error(),
@@ -556,6 +1003,7 @@ func (service *Service) decodeInboundIntent(requestID string, message *agentv1.A
 		}
 		intent.ConversationID = conversationID
 		intent.ConversationState = runRequest.GetConversationState()
+		intent.PreFetchedBlobs = runRequest.GetPreFetchedBlobs()
 		intent.UserMessage = extractUserMessage(message)
 		intent.RequestContext = extractRequestContext(message)
 		if service.shouldIgnoreEmptyResumeRunRequest(requestID, runRequest, intent.UserMessage, intent.RequestContext) {
@@ -603,6 +1051,7 @@ func (service *Service) decodeInboundIntent(requestID string, message *agentv1.A
 		intent.ConversationID = conversationID
 		intent.SubagentTypeName = strings.TrimSpace(prewarmRequest.GetSubagentTypeName())
 		intent.ConversationState = prewarmRequest.GetConversationState()
+		intent.PreFetchedBlobs = prewarmRequest.GetPreFetchedBlobs()
 		intent.Mode, intent.ModeSource, intent.HasExplicitMode, err = extractPrewarmMode(prewarmRequest)
 		if err != nil {
 			return InboundIntent{}, err
@@ -678,7 +1127,57 @@ func (service *Service) decodeInboundIntent(requestID string, message *agentv1.A
 }
 
 // handleRunIntent 处理 run/prewarm 类 intent，负责建会话、写 turn 和拉起 provider。
-func (service *Service) handleRunIntent(intent InboundIntent) error {
+func (service *Service) handleRunIntent(stream *ActiveStream, intent InboundIntent) (runErr error) {
+	setupContext := intent.Context
+	if setupContext == nil {
+		setupContext = context.Background()
+	}
+	setupContext, setupCancel := context.WithCancel(setupContext)
+	intent.Context = setupContext
+	if stream != nil {
+		stream.mu.Lock()
+		if intent.RunSetupGeneration == 0 ||
+			stream.RunSetupGeneration != intent.RunSetupGeneration ||
+			!stream.RunSetupActive {
+			stream.mu.Unlock()
+			setupCancel()
+			return context.Canceled
+		}
+		cancelRequested := stream.RunSetupCancelRequested
+		stream.RunSetupCancel = setupCancel
+		stream.mu.Unlock()
+		if cancelRequested {
+			setupCancel()
+		}
+	}
+	defer func() {
+		setupCancel()
+		ownsGeneration := false
+		if stream != nil {
+			stream.mu.Lock()
+			if stream.RunSetupGeneration == intent.RunSetupGeneration {
+				ownsGeneration = true
+				stream.RunSetupCancel = nil
+				stream.RunSetupActive = false
+				stream.RunSetupCancelRequested = false
+			}
+			stream.mu.Unlock()
+		}
+		if !ownsGeneration || runErr == nil {
+			return
+		}
+		if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+			_ = service.broker.CancelStream(stream, "[canceled] Run setup interrupted")
+			return
+		}
+		_ = service.broker.FailStream(stream, "unknown", runErr.Error())
+	}()
+	if err := setupContext.Err(); err != nil {
+		return err
+	}
+	if err := service.persistPreFetchedBlobs(intent.PreFetchedBlobs); err != nil {
+		return err
+	}
 	intent.UserMessage = normalizeUserMessageForStorage(intent.UserMessage)
 	if !intent.Prewarm {
 		service.cancelOtherConversationActors(
@@ -687,8 +1186,11 @@ func (service *Service) handleRunIntent(intent InboundIntent) error {
 			"[canceled] Superseded by newer request",
 		)
 	}
-	conversation, effectiveMode, turnSeq, initialEntries, err := service.bootstrapRuntimeConversation(intent)
+	conversation, effectiveMode, turnSeq, initialEntries, err := service.bootstrapRuntimeConversation(stream, intent)
 	if err != nil {
+		return err
+	}
+	if err := setupContext.Err(); err != nil {
 		return err
 	}
 	rewindDecision := service.decideRunRewind(intent, conversation)
@@ -737,7 +1239,7 @@ func (service *Service) handleRunIntent(intent InboundIntent) error {
 		deriveConversationLoopState(conversation)
 	}
 
-	stream, err := service.broker.OpenStream(intent.RequestID, intent.ConversationID, turnSeq, intent.ModelID, intent.ModelName, effectiveMode, userMessageText(intent.UserMessage))
+	stream, err = service.broker.OpenStream(intent.RequestID, intent.ConversationID, turnSeq, intent.ModelID, intent.ModelName, effectiveMode, userMessageText(intent.UserMessage))
 	if err != nil {
 		return err
 	}
@@ -759,6 +1261,7 @@ func (service *Service) handleRunIntent(intent InboundIntent) error {
 	stream.PendingExecs = make(map[string]runtimecore.PendingExec)
 	stream.PendingInteractions = make(map[string]runtimecore.PendingInteraction)
 	stream.RecentCompletedExecs = make(map[uint32]time.Time)
+	stream.RecentCompletedInteractions = make(map[uint32]time.Time)
 	stream.BackgroundShells = make(map[string]*BackgroundShellState)
 	stream.BackgroundShellsByMessageID = make(map[uint32]string)
 	stream.BackgroundShellsByExecID = make(map[string]string)
@@ -780,6 +1283,9 @@ func (service *Service) handleRunIntent(intent InboundIntent) error {
 	stream.UpdatedAt = time.Now().UTC()
 	stream.mu.Unlock()
 	service.setTurnPhase(stream, TurnPhaseIdle)
+	if err := setupContext.Err(); err != nil {
+		return err
+	}
 	service.debug.LogRuntime(context.Background(), intent.RequestID, intent.ConversationID, "stream_state_updated", map[string]any{
 		"turn_seq":                      turnSeq,
 		"model_id":                      strings.TrimSpace(intent.ModelID),
@@ -798,6 +1304,9 @@ func (service *Service) handleRunIntent(intent InboundIntent) error {
 	}
 	if intent.Prewarm {
 		return nil
+	}
+	if err := setupContext.Err(); err != nil {
+		return err
 	}
 	return service.requestProviderAction(stream, providerActionStart)
 }
@@ -862,7 +1371,7 @@ func (service *Service) handleCancelIntent(intent InboundIntent) error {
 	stream.UpdatedAt = time.Now().UTC()
 	stream.mu.Unlock()
 	service.setTurnPhase(stream, TurnPhaseCanceled)
-	return service.broker.Cancel(intent.RequestID, firstNonEmpty(intent.CancelReason, "[canceled] User aborted request"))
+	return service.broker.CancelStream(stream, firstNonEmpty(intent.CancelReason, "[canceled] User aborted request"))
 }
 
 // handleExecResult 处理客户端返回的执行桥结果，并在终态时把 tool_result 写回 history。
@@ -1245,6 +1754,445 @@ func (service *Service) handleMetadataIntent(intent InboundIntent) error {
 		}
 	}
 	return nil
+}
+
+func (service *Service) beginRunIngress(requestID string) uint64 {
+	if service == nil {
+		return 0
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return 0
+	}
+	generation := service.nextRunIngressID.Add(1)
+	if generation == 0 {
+		generation = service.nextRunIngressID.Add(1)
+	}
+	service.runSetupMu.Lock()
+	if service.runIngresses == nil {
+		service.runIngresses = make(map[string]map[uint64]*runIngressState)
+	}
+	if service.runIngresses[requestID] == nil {
+		service.runIngresses[requestID] = make(map[uint64]*runIngressState)
+	}
+	service.runIngresses[requestID][generation] = &runIngressState{}
+	service.notifyRunIngressChangedLocked()
+	service.runSetupMu.Unlock()
+	return generation
+}
+
+func (service *Service) endRunIngress(requestID string, generation uint64) {
+	if service == nil || generation == 0 {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	service.runSetupMu.Lock()
+	delete(service.runIngresses[requestID], generation)
+	if len(service.runIngresses[requestID]) == 0 {
+		delete(service.runIngresses, requestID)
+	}
+	service.notifyRunIngressChangedLocked()
+	service.runSetupMu.Unlock()
+}
+
+func (service *Service) bindCancelToRunIngress(requestID string, appendSeq int64) runIngressCancelBinding {
+	result := runIngressCancelBinding{}
+	if service == nil || appendSeq < 0 {
+		return result
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return result
+	}
+
+	service.runSetupMu.Lock()
+	defer service.runSetupMu.Unlock()
+	return service.bindCancelToRunIngressLocked(requestID, appendSeq, nil)
+}
+
+func (service *Service) bindCancelToActiveStream(requestID string) runIngressCancelBinding {
+	result := runIngressCancelBinding{}
+	if service == nil || service.broker == nil {
+		return result
+	}
+	stream, ok := service.broker.Get(strings.TrimSpace(requestID))
+	if !ok || stream == nil {
+		return result
+	}
+	stream.mu.Lock()
+	terminal := isTerminalStreamStatus(stream.Status) ||
+		stream.Phase == TurnPhaseCanceled ||
+		stream.Phase == TurnPhaseCompleted ||
+		stream.Phase == TurnPhaseFailed
+	lifecycleStarted := stream.RunSetupActive ||
+		strings.TrimSpace(stream.ConversationID) != "" ||
+		stream.ProviderActive ||
+		stream.CheckpointConversation != nil ||
+		len(stream.PendingExecs) > 0 ||
+		len(stream.PendingInteractions) > 0
+	if !terminal && lifecycleStarted {
+		result.bound = true
+		result.requestID = strings.TrimSpace(requestID)
+		result.stream = stream
+		result.setupGeneration = stream.RunSetupGeneration
+	}
+	stream.mu.Unlock()
+	return result
+}
+
+func (service *Service) bindCancelToRunIngressLocked(requestID string, appendSeq int64, targets map[uint64]struct{}) runIngressCancelBinding {
+	result := runIngressCancelBinding{}
+	if service == nil || appendSeq < 0 {
+		return result
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return result
+	}
+	ingresses := service.runIngresses[requestID]
+	if len(ingresses) == 0 {
+		return result
+	}
+
+	var acquired *runIngressState
+	var acquiredGeneration uint64
+	for generation, ingress := range ingresses {
+		if len(targets) > 0 {
+			if _, allowed := targets[generation]; !allowed {
+				continue
+			}
+		}
+		if ingress != nil && ingress.ticketAcquired && !ingress.ticketFinalized {
+			acquired = ingress
+			acquiredGeneration = generation
+			break
+		}
+	}
+	if acquired != nil {
+		result.bound = true
+		result.completeAppend = appendSeq > 0
+		result.appendGeneration = acquired.appendGeneration
+		result.requestID = requestID
+		result.ingressGeneration = acquiredGeneration
+		stream := acquired.setupStream
+		if stream == nil || acquired.setupGeneration == 0 {
+			return result
+		}
+		stream.mu.Lock()
+		if stream.RunSetupGeneration == acquired.setupGeneration && !isTerminalStreamStatus(stream.Status) {
+			result.stream = stream
+			result.setupGeneration = acquired.setupGeneration
+		}
+		stream.mu.Unlock()
+		return result
+	}
+
+	for generation, ingress := range ingresses {
+		if len(targets) > 0 {
+			if _, allowed := targets[generation]; !allowed {
+				continue
+			}
+		}
+		if ingress == nil || ingress.ticketFinalized {
+			continue
+		}
+		result.waiting = true
+	}
+	return result
+}
+
+func (service *Service) waitForRunIngressCancelBinding(ctx context.Context, requestID string, appendSeq int64, fingerprint [sha256.Size]byte) (runIngressCancelBinding, error) {
+	if service == nil || appendSeq <= 0 {
+		return runIngressCancelBinding{}, fmt.Errorf("run ingress cancellation is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timer := time.NewTimer(runIngressCancelWaitTimeout)
+	defer timer.Stop()
+	waiter := &runIngressCancelWaiter{appendSeq: appendSeq, fingerprint: fingerprint, done: make(chan struct{}), active: true}
+	service.runSetupMu.Lock()
+	if service.pendingRunCancelCount >= runIngressCancelWaiterLimit {
+		service.runSetupMu.Unlock()
+		return runIngressCancelBinding{}, fmt.Errorf("too many run ingress cancellations are waiting")
+	}
+	if !service.registerRunIngressCancelWaiterLocked(strings.TrimSpace(requestID), waiter) {
+		service.runSetupMu.Unlock()
+		return runIngressCancelBinding{}, fmt.Errorf("run ingress is no longer available for cancellation")
+	}
+	service.runSetupMu.Unlock()
+	defer func() {
+		service.runSetupMu.Lock()
+		service.unregisterRunIngressCancelWaiterLocked(strings.TrimSpace(requestID), waiter)
+		service.runSetupMu.Unlock()
+	}()
+	for {
+		service.runSetupMu.Lock()
+		binding := service.bindCancelToRunIngressLocked(requestID, appendSeq, waiter.targets)
+		signal := service.runIngressSignalLocked()
+		service.runSetupMu.Unlock()
+		if binding.bound {
+			return binding, nil
+		}
+		if !binding.waiting {
+			return runIngressCancelBinding{}, fmt.Errorf("run ingress is no longer available for cancellation")
+		}
+		select {
+		case <-waiter.done:
+			if waiter.err != nil {
+				return runIngressCancelBinding{}, waiter.err
+			}
+			return runIngressCancelBinding{bound: true}, nil
+		case <-ctx.Done():
+			return runIngressCancelBinding{}, ctx.Err()
+		case <-timer.C:
+			service.runSetupMu.Lock()
+			binding := service.bindCancelToRunIngressLocked(requestID, appendSeq, waiter.targets)
+			service.runSetupMu.Unlock()
+			if binding.bound {
+				return binding, nil
+			}
+			select {
+			case <-waiter.done:
+				if waiter.err != nil {
+					return runIngressCancelBinding{}, waiter.err
+				}
+				return runIngressCancelBinding{bound: true}, nil
+			default:
+			}
+			return runIngressCancelBinding{}, fmt.Errorf("run ingress was not ready for cancellation within %s", runIngressCancelWaitTimeout)
+		case <-signal:
+		}
+	}
+}
+
+func (service *Service) acquireRunIngressTicket(requestID string, generation uint64, ticket appendSequenceTicket) {
+	if service == nil || generation == 0 {
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	service.runSetupMu.Lock()
+	defer service.runSetupMu.Unlock()
+	ingresses := service.runIngresses[requestID]
+	ingress := ingresses[generation]
+	if ingress == nil {
+		return
+	}
+	ingress.ticketAcquired = true
+	ingress.appendGeneration = ticket.Generation()
+	for candidateGeneration := range ingresses {
+		if candidateGeneration != generation {
+			delete(ingresses, candidateGeneration)
+		}
+	}
+	for waiter := range ingress.cancelWaiters {
+		if waiter == nil || !waiter.active {
+			continue
+		}
+		completion := ticket.CompleteAheadWithFingerprint(waiter.appendSeq, &waiter.fingerprint)
+		if completion.retry {
+			waiter.err = fmt.Errorf("append replay prefix is not ready for cancellation")
+		} else if !completion.stale {
+			ingress.cancelRequested = true
+		}
+		service.unregisterRunIngressCancelWaiterLocked(requestID, waiter)
+		waiter.once.Do(func() { close(waiter.done) })
+	}
+	ingress.cancelWaiters = nil
+	service.notifyRunIngressChangedLocked()
+}
+
+func (service *Service) runIngressSignalLocked() <-chan struct{} {
+	if service.runIngressChanged == nil {
+		service.runIngressChanged = make(chan struct{})
+	}
+	return service.runIngressChanged
+}
+
+func (service *Service) notifyRunIngressChangedLocked() {
+	service.runIngressSignalLocked()
+	close(service.runIngressChanged)
+	service.runIngressChanged = make(chan struct{})
+}
+
+func (service *Service) registerRunIngressCancelWaiterLocked(requestID string, waiter *runIngressCancelWaiter) bool {
+	if requestID == "" || waiter == nil || service.pendingRunCancelCount >= runIngressCancelWaiterLimit {
+		return false
+	}
+	waiter.targets = make(map[uint64]struct{})
+	for generation, ingress := range service.runIngresses[requestID] {
+		if ingress != nil && !ingress.ticketFinalized {
+			waiter.targets[generation] = struct{}{}
+		}
+	}
+	if len(waiter.targets) == 0 {
+		return false
+	}
+	if service.pendingRunCancelWaiters == nil {
+		service.pendingRunCancelWaiters = make(map[string]map[*runIngressCancelWaiter]struct{})
+	}
+	if service.pendingRunCancelWaiters[requestID] == nil {
+		service.pendingRunCancelWaiters[requestID] = make(map[*runIngressCancelWaiter]struct{})
+	}
+	service.pendingRunCancelWaiters[requestID][waiter] = struct{}{}
+	service.pendingRunCancelCount++
+	for generation, ingress := range service.runIngresses[requestID] {
+		if _, targeted := waiter.targets[generation]; !targeted {
+			continue
+		}
+		if ingress == nil || ingress.ticketAcquired || ingress.ticketFinalized {
+			continue
+		}
+		if ingress.cancelWaiters == nil {
+			ingress.cancelWaiters = make(map[*runIngressCancelWaiter]struct{})
+		}
+		ingress.cancelWaiters[waiter] = struct{}{}
+	}
+	return true
+}
+
+func (service *Service) unregisterRunIngressCancelWaiterLocked(requestID string, waiter *runIngressCancelWaiter) {
+	if waiter == nil || !waiter.active {
+		return
+	}
+	waiter.active = false
+	if waiters := service.pendingRunCancelWaiters[requestID]; waiters != nil {
+		if _, ok := waiters[waiter]; ok {
+			delete(waiters, waiter)
+			if service.pendingRunCancelCount > 0 {
+				service.pendingRunCancelCount--
+			}
+		}
+		if len(waiters) == 0 {
+			delete(service.pendingRunCancelWaiters, requestID)
+		}
+	}
+	for _, ingress := range service.runIngresses[requestID] {
+		delete(ingress.cancelWaiters, waiter)
+	}
+}
+
+func (service *Service) finishRunIngressTicket(requestID string, generation uint64, ticket appendSequenceTicket) {
+	if service == nil || generation == 0 {
+		ticket.Release()
+		return
+	}
+	requestID = strings.TrimSpace(requestID)
+	service.runSetupMu.Lock()
+	if ingress := service.runIngresses[requestID][generation]; ingress != nil {
+		ingress.ticketFinalized = true
+	}
+	ticket.Release()
+	delete(service.runIngresses[requestID], generation)
+	if len(service.runIngresses[requestID]) == 0 {
+		delete(service.runIngresses, requestID)
+	}
+	service.notifyRunIngressChangedLocked()
+	service.runSetupMu.Unlock()
+}
+
+func (service *Service) dispatchRunIngressCancel(binding runIngressCancelBinding, intent InboundIntent) {
+	binding = service.activateRunIngressCancelBinding(binding)
+	if binding.setupCancel != nil {
+		binding.setupCancel()
+	}
+	if binding.stream == nil {
+		return
+	}
+	if err := service.postStreamCommandAsync(binding.stream, streamCommand{Kind: streamCommandCancel, Intent: intent}); err != nil {
+		_ = service.broker.CancelStream(binding.stream, firstNonEmpty(intent.CancelReason, "[canceled] User aborted request"))
+	}
+}
+
+func (service *Service) activateRunIngressCancelBinding(binding runIngressCancelBinding) runIngressCancelBinding {
+	if service == nil || !binding.bound {
+		return binding
+	}
+	if binding.ingressGeneration != 0 {
+		service.runSetupMu.Lock()
+		ingress := service.runIngresses[strings.TrimSpace(binding.requestID)][binding.ingressGeneration]
+		if ingress != nil && !ingress.ticketFinalized {
+			ingress.cancelRequested = true
+			if ingress.setupStream != nil && ingress.setupGeneration != 0 {
+				binding.stream = ingress.setupStream
+				binding.setupGeneration = ingress.setupGeneration
+			}
+		}
+		service.runSetupMu.Unlock()
+	}
+	if binding.stream == nil {
+		return binding
+	}
+	binding.stream.mu.Lock()
+	if (binding.setupGeneration == 0 || binding.stream.RunSetupGeneration == binding.setupGeneration) &&
+		!isTerminalStreamStatus(binding.stream.Status) {
+		if binding.stream.RunSetupActive {
+			binding.stream.RunSetupCancelRequested = true
+			binding.setupCancel = binding.stream.RunSetupCancel
+		}
+	}
+	binding.stream.mu.Unlock()
+	return binding
+}
+
+func (service *Service) hasCancelableStreamLifecycle(requestID string) bool {
+	if service == nil || service.broker == nil {
+		return false
+	}
+	stream, ok := service.broker.Get(strings.TrimSpace(requestID))
+	return ok && isCancelableStreamLifecycle(stream)
+}
+
+func isCancelableStreamLifecycle(stream *ActiveStream) bool {
+	if stream == nil {
+		return false
+	}
+	stream.mu.Lock()
+	terminal := isTerminalStreamStatus(stream.Status) ||
+		stream.Phase == TurnPhaseCanceled ||
+		stream.Phase == TurnPhaseCompleted ||
+		stream.Phase == TurnPhaseFailed
+	lifecycleStarted := stream.RunSetupActive ||
+		strings.TrimSpace(stream.ConversationID) != "" ||
+		stream.ProviderActive ||
+		stream.CheckpointConversation != nil ||
+		len(stream.PendingExecs) > 0 ||
+		len(stream.PendingInteractions) > 0
+	stream.mu.Unlock()
+	return !terminal && lifecycleStarted
+}
+
+func (service *Service) beginRunSetup(stream *ActiveStream, ingressGeneration uint64) uint64 {
+	if stream == nil {
+		return 0
+	}
+	service.runSetupMu.Lock()
+	ingressCanceled := false
+	ingress := service.runIngresses[strings.TrimSpace(stream.RequestID)][ingressGeneration]
+	if ingress != nil {
+		ingressCanceled = ingress.cancelRequested
+	}
+	stream.mu.Lock()
+	previousCancel := stream.RunSetupCancel
+	consumeEarlyCancel := !stream.RunSetupActive && (stream.RunSetupCancelRequested || ingressCanceled)
+	stream.RunSetupGeneration++
+	if stream.RunSetupGeneration == 0 {
+		stream.RunSetupGeneration++
+	}
+	generation := stream.RunSetupGeneration
+	stream.RunSetupActive = true
+	stream.RunSetupCancelRequested = consumeEarlyCancel
+	stream.RunSetupCancel = nil
+	if ingress != nil {
+		ingress.setupStream = stream
+		ingress.setupGeneration = generation
+	}
+	stream.mu.Unlock()
+	service.runSetupMu.Unlock()
+	if previousCancel != nil {
+		previousCancel()
+	}
+	return generation
 }
 
 func (service *Service) scheduleProviderResume(stream *ActiveStream, _ int) error {
@@ -2116,7 +3064,7 @@ func (service *Service) completeSuccessfulTurn(stream *ActiveStream, completion 
 			err,
 		)
 	}
-	if err := service.publishCheckpoint(requestID, conversationID); err != nil {
+	if err := service.publishRequiredCheckpoint(requestID, conversationID); err != nil {
 		return err
 	}
 	if err := service.broker.Publish(requestID, StreamEvent{
@@ -2124,7 +3072,7 @@ func (service *Service) completeSuccessfulTurn(stream *ActiveStream, completion 
 	}); err != nil {
 		return err
 	}
-	if err := service.broker.Complete(requestID, "", ""); err != nil {
+	if err := service.broker.CompleteStream(stream, "", ""); err != nil {
 		return err
 	}
 	service.setTurnPhase(stream, TurnPhaseCompleted)
@@ -2146,6 +3094,14 @@ func (service *Service) failStreamIfNonTerminal(stream *ActiveStream, terminalCo
 
 // publishCheckpoint 按当前内存会话镜像投影出 checkpoint，并广播给所有 RunSSE 订阅者。
 func (service *Service) publishCheckpoint(requestID string, _ string) error {
+	return service.publishCheckpointWithBlobRequirement(requestID, false)
+}
+
+func (service *Service) publishRequiredCheckpoint(requestID string, _ string) error {
+	return service.publishCheckpointWithBlobRequirement(requestID, true)
+}
+
+func (service *Service) publishCheckpointWithBlobRequirement(requestID string, requireBlobDelivery bool) error {
 	stream, ok := service.broker.Get(requestID)
 	if !ok || stream == nil {
 		return fmt.Errorf("request is not active: %s", requestID)
@@ -2154,14 +3110,20 @@ func (service *Service) publishCheckpoint(requestID string, _ string) error {
 	if err != nil {
 		return err
 	}
-	state, err := service.projector.ProjectLegacyCheckpoint(conversation)
+	projection, err := service.projector.ProjectLegacyCheckpointWithBlobs(conversation)
 	if err != nil {
 		return err
 	}
+	if err := service.persistCheckpointBlobs(projection.Blobs); err != nil {
+		return err
+	}
+	state := projection.State
 	state.PendingToolCalls = buildPendingToolCalls(pendingExecs, pendingInteractions)
 	service.rewriteCheckpointTokenDetailsForClient(stream, conversation, state)
 	return service.broker.Publish(requestID, StreamEvent{
-		Message: buildCheckpointMessage(state),
+		Message:             buildCheckpointMessage(state),
+		CheckpointBlobIDs:   checkpointBlobIDs(projection.Blobs),
+		RequireBlobDelivery: requireBlobDelivery,
 	})
 }
 
@@ -2310,7 +3272,7 @@ func (service *Service) failActiveStream(stream *ActiveStream, conversationID st
 	if err := service.publishCheckpoint(requestID, conversationID); err != nil && firstErr == nil {
 		firstErr = err
 	}
-	if err := service.broker.Fail(requestID, terminalCode, terminalMessage); err != nil && firstErr == nil {
+	if err := service.broker.FailStream(stream, terminalCode, terminalMessage); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	return firstErr
@@ -3199,7 +4161,7 @@ func markExecCompleted(stream *ActiveStream, pending runtimecore.PendingExec) {
 		return
 	}
 	now := time.Now().UTC()
-	cutoff := now.Add(-completedExecRetention)
+	cutoff := now.Add(-completedClientResponseRetention)
 
 	stream.mu.Lock()
 	delete(stream.PendingExecs, pending.ExecID)
@@ -3223,7 +4185,7 @@ func recentlyCompletedExecExists(stream *ActiveStream, messageID uint32) bool {
 		return false
 	}
 	now := time.Now().UTC()
-	cutoff := now.Add(-completedExecRetention)
+	cutoff := now.Add(-completedClientResponseRetention)
 
 	stream.mu.Lock()
 	defer stream.mu.Unlock()

--- a/internal/backend/forwarder/token_usage.go
+++ b/internal/backend/forwarder/token_usage.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -45,26 +46,18 @@ func (snapshot turnUsageSnapshot) requestTokensTotal() int64 {
 	return snapshot.promptTokensTotal() + nonNegativeInt64(snapshot.OutputTokens)
 }
 
-func (service *Service) importConversationState(item *ConversationFile, state *agentv1.ConversationStateStructure) ([]HistoryEntry, error) {
+func (service *Service) importConversationState(ctx context.Context, stream *ActiveStream, item *ConversationFile, state *agentv1.ConversationStateStructure) ([]HistoryEntry, error) {
 	if item == nil || state == nil {
 		return nil, nil
 	}
-	item.TokenDetailsUsedTokens = state.GetTokenDetails().GetUsedTokens()
-	entries := make([]HistoryEntry, 0, 2)
-	if messages, err := importedConversationStateModelMessages(state); err != nil {
+	materialized, err := service.materializeConversationState(ctx, stream, state)
+	if err != nil {
 		return nil, err
-	} else {
-		for _, message := range messages {
-			entry, ok, err := newModelMessageEntry(0, "", message)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				entries = append(entries, entry)
-			}
-		}
 	}
-	if len(entries) == 0 {
+	state = materialized
+	item.TokenDetailsUsedTokens = state.GetTokenDetails().GetUsedTokens()
+	entries := make([]HistoryEntry, 0, 4)
+	if len(state.GetRootPromptMessagesJson()) == 0 {
 		summary, ok, err := importedConversationStateSummary(state)
 		if err != nil {
 			return nil, err
@@ -83,6 +76,19 @@ func (service *Service) importConversationState(item *ConversationFile, state *a
 				Kind:    "compacted_summary",
 				Payload: payload,
 			})
+		}
+	}
+	if messages, err := importedConversationStateModelMessages(state); err != nil {
+		return nil, err
+	} else {
+		for _, message := range messages {
+			entry, ok, err := newModelMessageEntry(0, "", message)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				entries = append(entries, entry)
+			}
 		}
 	}
 	runtimeState, ok, err := runtimeStatePayloadFromConversationState(state)

--- a/internal/backend/forwarder/types.go
+++ b/internal/backend/forwarder/types.go
@@ -107,7 +107,10 @@ const (
 
 type StreamEvent struct {
 	Message              *agentv1.AgentServerMessage
+	CheckpointBlobIDs    [][]byte
+	RequireBlobDelivery  bool
 	End                  bool
+	TerminalEpoch        uint64
 	TerminalErrorCode    string
 	TerminalErrorMessage string
 }
@@ -124,6 +127,7 @@ type manualCompactionDirective struct {
 type ActiveStream struct {
 	mu sync.Mutex
 
+	InstanceID             uint64
 	RequestID              string
 	ConversationID         string
 	TurnSeq                int64
@@ -139,6 +143,10 @@ type ActiveStream struct {
 	CurrentModelCallID                          string
 	ProviderActive                              bool
 	ProviderCancel                              func()
+	RunSetupCancel                              context.CancelFunc
+	RunSetupGeneration                          uint64
+	RunSetupActive                              bool
+	RunSetupCancelRequested                     bool
 	ProviderPassCount                           int
 	ToolInvocationCount                         int
 	ActorMailbox                                chan streamCommandEnvelope
@@ -175,15 +183,38 @@ type ActiveStream struct {
 	TerminalsFolder             string
 	RequestFileContents         map[string]string
 	RecentCompletedExecs        map[uint32]time.Time
+	RecentCompletedInteractions map[uint32]time.Time
 	BackgroundShells            map[string]*BackgroundShellState
 	BackgroundShellsByMessageID map[uint32]string
 	BackgroundShellsByExecID    map[string]string
 	BackgroundShellActions      map[string]time.Time
+	PendingKVAcks               map[uint32]*pendingKVAck
+	TerminalEpoch               uint64
+	PendingTerminalDeliveries   map[string]uint64
+	TerminalReplayRequired      bool
 	TerminalCleanupTimer        *time.Timer
 	TerminalCleanupSeq          atomic.Uint64
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+type pendingKVOperation uint8
+
+const (
+	pendingKVOperationSetBlob pendingKVOperation = iota + 1
+	pendingKVOperationGetBlob
+)
+
+type pendingKVAck struct {
+	id         uint32
+	digest     [32]byte
+	kind       pendingKVOperation
+	done       chan struct{}
+	notify     chan<- struct{}
+	onComplete func()
+	once       sync.Once
+	err        error
 }
 
 type BackgroundShellState struct {
@@ -403,6 +434,7 @@ const (
 )
 
 type InboundIntent struct {
+	Context                  context.Context
 	Kind                     string
 	RequestID                string
 	ConversationID           string
@@ -417,6 +449,7 @@ type InboundIntent struct {
 	SubagentTypeName         string
 	SubagentModelOverrides   map[string]runtimecore.SubagentModelOverrideSelection
 	ConversationState        *agentv1.ConversationStateStructure
+	PreFetchedBlobs          []*agentv1.PreFetchedBlob
 	UserMessage              *agentv1.UserMessage
 	RequestContext           *agentv1.RequestContext
 	ClientMessage            *agentv1.AgentClientMessage
@@ -427,6 +460,8 @@ type InboundIntent struct {
 	CancelReason             string
 	IgnoredReason            string
 	Prewarm                  bool
+	RunIngressGeneration     uint64
+	RunSetupGeneration       uint64
 }
 
 // normalizeMode 对外部传入的 mode 做最小归一化，但不再静默降级。

--- a/internal/backend/host.go
+++ b/internal/backend/host.go
@@ -270,6 +270,8 @@ func (host *Host) rebuildLocked(cfg serverconfig.Config) error {
 	agentModule := forwarder.NewModule(appdata.HistoryRootPath(), host.configs)
 	legacyBidiAppendProcedure := "/aiserver.v1.BidiService/BidiAppend"
 	legacyRunSSEProcedure := "/agent.v1.AgentService/RunSSE"
+	uploadConversationBlobsProcedure := "/agent.v1.AgentService/UploadConversationBlobs"
+	notifyConversationCloneProcedure := "/agent.v1.AgentService/NotifyConversationClone"
 	routeDeps := upstream.Dependencies{
 		SystemSettingService: &serverSystemSettings{configs: host.configs},
 		HTTPClient:           netproxy.NewHTTPClient(30000 * time.Second),
@@ -302,6 +304,22 @@ func (host *Host) rebuildLocked(cfg serverconfig.Config) error {
 			server.Local(server.HTTPHandlerAction(agentModule.LocalRunSSE)),
 			server.Upstream(upstream.DirectAction(routeDeps, upstream.CompatRouteConfig{
 				Name: "run_sse",
+			})),
+		),
+		server.POST(uploadConversationBlobsProcedure,
+			server.Name("upload_conversation_blobs"),
+			server.ConnectUnary(),
+			server.Local(server.HTTPHandlerAction(agentModule.LocalUploadConversationBlobs)),
+			server.Upstream(upstream.DirectAction(routeDeps, upstream.CompatRouteConfig{
+				Name: "upload_conversation_blobs",
+			})),
+		),
+		server.POST(notifyConversationCloneProcedure,
+			server.Name("notify_conversation_clone"),
+			server.ConnectUnary(),
+			server.Local(server.HTTPHandlerAction(agentModule.LocalNotifyConversationClone)),
+			server.Upstream(upstream.DirectAction(routeDeps, upstream.CompatRouteConfig{
+				Name: "notify_conversation_clone",
 			})),
 		),
 		server.POST("/aiserver.v1.AiService/ServerTime",

--- a/proto/aiserver_v1.proto
+++ b/proto/aiserver_v1.proto
@@ -2056,6 +2056,7 @@ message BidiAppendRequest {
   string data = 1;
   BidiRequestId request_id = 2;
   int64 append_seqno = 3;
+  bytes data_binary = 4;
 }
 
 // Copied from: local:aiserver.v1.BidiAppendResponse (var: MSe)

--- a/proto/from_extensions/aiserver_v1.proto
+++ b/proto/from_extensions/aiserver_v1.proto
@@ -2056,6 +2056,7 @@ message BidiAppendRequest {
   string data = 1;
   BidiRequestId request_id = 2;
   int64 append_seqno = 3;
+  bytes data_binary = 4;
 }
 
 // Copied from: local:aiserver.v1.BidiAppendResponse (var: MSe)


### PR DESCRIPTION
## 变更说明 / What

修复本地模式下 Fork Chat 无法正确打开和承接历史的问题。

- 支持 Conversation Blob 上传、获取与 clone checkpoint 恢复
- 从 fork checkpoint 恢复模型历史，并允许 fork 产生的会话再次 fork
- 修正 Bidi append 重放、取消和 KV 应答的序列生命周期
- 处理重复 seq0、在途 append 与并发 waiter，避免 replay 消息被误判为 stale
- 保持模型可见历史顺序稳定，避免破坏 prefix cache

## 关联 Issue / Related Issue

Fixes #152

## 测试方式 / How to Test

- `gofmt` 检查通过
- `git diff --check` 通过
- `go vet ./internal/backend/forwarder ./internal/backend` 通过
- `go build ./...` 通过
- Windows 本地构建 `0.0.42-fork-chat.3` 手动验证：
  - 同一会话连续 fork 时名称按顺序递增
  - fork 产生的会话可以再次 fork
  - 正常消息发送与工具调用可继续使用

## 检查清单 / Checklist

- [x] 代码已通过 `gofmt` 和 `go vet` / Code passes `gofmt` and `go vet`
- [x] 前端构建无报错 / Frontend builds without errors
- [x] 未新增 UI 文案，无 locale 同步需求 / No new UI strings
- [x] 提交信息符合 Conventional Commits 规范 / Commit messages follow Conventional Commits
