### PR TITLE
fix:解决 VDI 环境（如 VMware Horizon）导致主窗口白屏。

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -8,7 +8,9 @@ import (
 	"encoding/pem"
 	"io/fs"
 	"net"
+	"os"
 	goruntime "runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +39,8 @@ const (
 	appName = "Cursor助手"
 	// adRefreshInterval 表示后台广告拉取间隔。
 	adRefreshInterval = 3 * time.Minute
+	// disableWebViewSandboxEnv allows affected VDI users to opt out of the WebView2 sandbox.
+	disableWebViewSandboxEnv = "CURSOR_BYOK_DISABLE_WEBVIEW_SANDBOX"
 )
 
 // EmbeddedResources 定义了当前模块中的 EmbeddedResources 类型。
@@ -135,9 +139,7 @@ func Run(resources EmbeddedResources) error {
 			Handler: application.AssetFileServerFS(resources.Assets),
 		},
 		Windows: application.WindowsOptions{
-			// VDI 环境（如 VMware Horizon）会阻止 WebView2 创建沙箱受限令牌的renderer 进程，导致主窗口白屏。
-			// --no-sandbox 跳过受限沙箱创建，使渲染进程可以正常启动。
-			AdditionalBrowserArgs: []string{"--no-sandbox"},
+			AdditionalBrowserArgs: windowsAdditionalBrowserArgs(),
 		},
 		Mac: application.MacOptions{
 			ActivationPolicy: application.ActivationPolicyAccessory,
@@ -418,6 +420,14 @@ func Run(resources EmbeddedResources) error {
 	refreshTray()
 
 	return app.Run()
+}
+
+func windowsAdditionalBrowserArgs() []string {
+	disableSandbox, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(disableWebViewSandboxEnv)))
+	if err != nil || !disableSandbox {
+		return nil
+	}
+	return []string{"--no-sandbox"}
 }
 
 func browserReachableLoopbackBaseURL(listenAddr string) string {

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -134,6 +134,11 @@ func Run(resources EmbeddedResources) error {
 		Assets: application.AssetOptions{
 			Handler: application.AssetFileServerFS(resources.Assets),
 		},
+		Windows: application.WindowsOptions{
+			// VDI 环境（如 VMware Horizon）会阻止 WebView2 创建沙箱受限令牌的renderer 进程，导致主窗口白屏。
+			// --no-sandbox 跳过受限沙箱创建，使渲染进程可以正常启动。
+			AdditionalBrowserArgs: []string{"--no-sandbox"},
+		},
 		Mac: application.MacOptions{
 			ActivationPolicy: application.ActivationPolicyAccessory,
 			ApplicationShouldTerminateAfterLastWindowClosed: false,

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWindowsAdditionalBrowserArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{name: "unset"},
+		{name: "enabled with one", env: "1", want: []string{"--no-sandbox"}},
+		{name: "enabled with true", env: " true ", want: []string{"--no-sandbox"}},
+		{name: "disabled", env: "false"},
+		{name: "invalid", env: "yes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(disableWebViewSandboxEnv, tt.env)
+			if got := windowsAdditionalBrowserArgs(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("windowsAdditionalBrowserArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
VDI 环境（如 VMware Horizon）可能阻止 WebView2 创建沙箱受限令牌的 renderer 进程，导致主窗口白屏。

为避免对所有 Windows 用户全局关闭 WebView2 沙箱，本修复改为显式启用。仅受影响的 VDI 用户需要在启动应用前设置：

```powershell
$env:CURSOR_BYOK_DISABLE_WEBVIEW_SANDBOX = "1"
```

该选项会向 WebView2 添加 `--no-sandbox`。它会降低渲染进程隔离，仅应作为受影响 VDI 环境的兼容措施使用。默认情况下沙箱保持启用。