### PR TITLE
fix(forwarder): wait for shell approval before recovery

### DIFF
--- a/internal/backend/agent/core/types.go
+++ b/internal/backend/agent/core/types.go
@@ -210,6 +210,14 @@ type PendingAssistantOutput struct {
 	TextPreview string
 }
 
+// ShellApprovalState describes the confirmation state separating from the stream state.
+type ShellApprovalState string
+
+const (
+	ShellApprovalStateAwaiting ShellApprovalState = "awaiting_shell_approval"
+	ShellApprovalStateRunning  ShellApprovalState = "running"
+)
+
 // PendingExec 表示一条尚未收口的执行桥记录。
 type PendingExec struct {
 	// MessageID 是打开该执行桥时下发给客户端的桥消息编号。
@@ -234,6 +242,8 @@ type PendingExec struct {
 	ExecKind string
 	// StreamState 描述当前流式执行桥的阶段。
 	StreamState string
+	// ShellApprovalState 描述 shell 是否已获得用户确认并开始执行。
+	ShellApprovalState ShellApprovalState
 	// OpenedAt 表示执行桥请求发出的时间。
 	OpenedAt time.Time
 	// FirstChunkAt 表示 shellStream 首个输出块时间。

--- a/internal/backend/forwarder/service.go
+++ b/internal/backend/forwarder/service.go
@@ -989,6 +989,9 @@ func (service *Service) handleExecResult(intent InboundIntent) error {
 	service.observeBackgroundShellExecClientMessage(stream, pending, intent.ExecClientMessage)
 	service.observeShellExecClientMessage(stream, pending, intent.ExecClientMessage)
 	pending = service.applyExecProgress(stream, pending, intent.ExecClientMessage)
+	if strings.TrimSpace(pending.ExecKind) == "shell" {
+		service.scheduleShellForegroundRecovery(intent.RequestID, pending)
+	}
 	if isHiddenPatchEditExecKind(pending.ExecKind) {
 		return service.handleHiddenPatchEditExecResult(stream, pending, intent.ExecClientMessage)
 	}
@@ -2028,6 +2031,10 @@ func (service *Service) applyExecProgress(stream *ActiveStream, pending runtimec
 		return pending
 	}
 	now := time.Now().UTC()
+	switch shellStream.GetEvent().(type) {
+	case *agentv1.ShellStream_Stdout, *agentv1.ShellStream_Stderr, *agentv1.ShellStream_Start:
+		current = markShellRunning(current)
+	}
 	switch event := shellStream.GetEvent().(type) {
 	case *agentv1.ShellStream_Stdout:
 		if current.FirstChunkAt.IsZero() {

--- a/internal/backend/forwarder/shell_recovery.go
+++ b/internal/backend/forwarder/shell_recovery.go
@@ -27,6 +27,28 @@ func initializePendingExecForTracking(pending runtimecore.PendingExec) runtimeco
 	if pending.LastShellActivityAt.IsZero() {
 		pending.LastShellActivityAt = pending.OpenedAt
 	}
+	if pending.ShellApprovalState == "" {
+		switch strings.TrimSpace(pending.StreamState) {
+		case "started", "streaming":
+			pending.ShellApprovalState = runtimecore.ShellApprovalStateRunning
+		default:
+			pending.ShellApprovalState = runtimecore.ShellApprovalStateAwaiting
+		}
+	}
+	if pending.ShellApprovalState == runtimecore.ShellApprovalStateRunning && pending.ShellForegroundDeadline.IsZero() {
+		pending.ShellForegroundDeadline = pending.OpenedAt.Add(shellForegroundTimeoutDuration(pending.ArgsJSON) + shellTerminalRecoveryGrace)
+	}
+	return pending
+}
+
+func markShellRunning(pending runtimecore.PendingExec) runtimecore.PendingExec {
+	if strings.TrimSpace(pending.ExecKind) != "shell" {
+		return pending
+	}
+	pending.ShellApprovalState = runtimecore.ShellApprovalStateRunning
+	if pending.OpenedAt.IsZero() {
+		pending.OpenedAt = time.Now().UTC()
+	}
 	if pending.ShellForegroundDeadline.IsZero() {
 		pending.ShellForegroundDeadline = pending.OpenedAt.Add(shellForegroundTimeoutDuration(pending.ArgsJSON) + shellTerminalRecoveryGrace)
 	}
@@ -52,7 +74,7 @@ func shellForegroundTimeoutMS(argsJSON []byte) int64 {
 }
 
 func (service *Service) scheduleShellForegroundRecovery(requestID string, pending runtimecore.PendingExec) {
-	if service == nil || strings.TrimSpace(requestID) == "" || strings.TrimSpace(pending.ExecKind) != "shell" || strings.TrimSpace(pending.ExecID) == "" {
+	if service == nil || strings.TrimSpace(requestID) == "" || strings.TrimSpace(pending.ExecKind) != "shell" || strings.TrimSpace(pending.ExecID) == "" || pending.ShellApprovalState != runtimecore.ShellApprovalStateRunning {
 		return
 	}
 	stream, ok := service.broker.Get(requestID)
@@ -133,6 +155,9 @@ func (service *Service) recoverShellWithoutTerminalIfNeeded(stream *ActiveStream
 	if !found || current.MessageID != messageID || strings.TrimSpace(current.ExecKind) != "shell" || isTerminalStreamStatus(status) {
 		return nil
 	}
+	if current.ShellApprovalState != runtimecore.ShellApprovalStateRunning {
+		return nil
+	}
 	switch strings.TrimSpace(current.StreamState) {
 	case "exited", "backgrounded", "rejected", "permission_denied":
 		return nil
@@ -168,6 +193,7 @@ func (service *Service) recoverShellWithoutTerminal(stream *ActiveStream, pendin
 			"message_id":               pending.MessageID,
 			"exec_id":                  pending.ExecID,
 			"exec_kind":                pending.ExecKind,
+			"approval_state":           pending.ShellApprovalState,
 			"reason":                   strings.TrimSpace(reason),
 			"recent_stream_state":      pending.StreamState,
 			"chunk_count":              pending.ChunkCount,

--- a/internal/backend/forwarder/shell_recovery_test.go
+++ b/internal/backend/forwarder/shell_recovery_test.go
@@ -358,7 +358,11 @@ func testShellRecoveryFixture(t *testing.T, state string) (*Service, *ActiveStre
 		projector:  NewHistoryProjector(),
 		execBridge: execbridge.NewBridge(),
 	}
-	if err := service.replaceCheckpointConversation(stream, testConversation(nil)); err != nil {
+	if err := service.replaceCheckpointConversation(stream, &ConversationFile{
+		ConversationID:     stream.ConversationID,
+		RootConversationID: stream.ConversationID,
+		Mode:               "agent",
+	}); err != nil {
 		t.Fatalf("replaceCheckpointConversation() error = %v", err)
 	}
 	pending := initializePendingExecForTracking(runtimecore.PendingExec{

--- a/internal/backend/forwarder/shell_recovery_test.go
+++ b/internal/backend/forwarder/shell_recovery_test.go
@@ -1,0 +1,436 @@
+package forwarder
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"cursor/gen/agentv1"
+	execbridge "cursor/internal/backend/agent/bridge/exec"
+	runtimecore "cursor/internal/backend/agent/core"
+)
+
+func TestInitializePendingShellWaitsForApprovalBeforeStartingDeadline(t *testing.T) {
+	openedAt := time.Now().UTC().Add(-time.Minute)
+	pending := initializePendingExecForTracking(runtimecore.PendingExec{
+		ExecID:      "exec-shell-approval",
+		ExecKind:    "shell",
+		OpenedAt:    openedAt,
+		ArgsJSON:    []byte(`{"block_until_ms":30000}`),
+		StreamState: "opened",
+	})
+	if pending.ShellApprovalState != runtimecore.ShellApprovalStateAwaiting {
+		t.Fatalf("shell approval state = %q, want %q", pending.ShellApprovalState, runtimecore.ShellApprovalStateAwaiting)
+	}
+	if !pending.ShellForegroundDeadline.IsZero() {
+		t.Fatalf("foreground deadline = %s, want zero while awaiting approval", pending.ShellForegroundDeadline)
+	}
+}
+
+func TestInitializeRunningShellStartsForegroundDeadline(t *testing.T) {
+	openedAt := time.Now().UTC().Add(-time.Second)
+	pending := initializePendingExecForTracking(runtimecore.PendingExec{
+		ExecID:             "exec-shell-running",
+		ExecKind:           "shell",
+		OpenedAt:           openedAt,
+		ArgsJSON:           []byte(`{"block_until_ms":30000}`),
+		StreamState:        "started",
+		ShellApprovalState: runtimecore.ShellApprovalStateRunning,
+	})
+	wantDeadline := openedAt.Add(30*time.Second + shellTerminalRecoveryGrace)
+	if pending.ShellApprovalState != runtimecore.ShellApprovalStateRunning {
+		t.Fatalf("shell approval state = %q, want %q", pending.ShellApprovalState, runtimecore.ShellApprovalStateRunning)
+	}
+	if !pending.ShellForegroundDeadline.Equal(wantDeadline) {
+		t.Fatalf("foreground deadline = %s, want %s", pending.ShellForegroundDeadline, wantDeadline)
+	}
+}
+
+func TestShellForegroundRecoveryDoesNotCloseWhileAwaitingApproval(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "opened")
+	pending.ShellApprovalState = runtimecore.ShellApprovalStateAwaiting
+	pending.ShellForegroundDeadline = time.Now().UTC().Add(-time.Minute)
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonForegroundDeadline); err != nil {
+		t.Fatalf("approval recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); !found {
+		t.Fatal("approval timeout completed shell without Run or Skip")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 0 {
+		t.Fatalf("approval timeout emitted %d completions, want 0", completions)
+	}
+}
+
+func TestShellStartTransitionsApprovalToRunning(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "opened")
+	start := &agentv1.ExecClientMessage{
+		Id:     pending.MessageID,
+		ExecId: pending.ExecID,
+		Message: &agentv1.ExecClientMessage_ShellStream{
+			ShellStream: &agentv1.ShellStream{
+				Event: &agentv1.ShellStream_Start{Start: &agentv1.ShellStreamStart{}},
+			},
+		},
+	}
+
+	if err := service.handleExecResult(InboundIntent{RequestID: stream.RequestID, ExecClientMessage: start}); err != nil {
+		t.Fatalf("shell start error = %v", err)
+	}
+	current, found := snapshotPendingExec(stream, pending.ExecID)
+	if !found {
+		t.Fatal("shell start removed pending exec")
+	}
+	if current.ShellApprovalState != runtimecore.ShellApprovalStateRunning {
+		t.Fatalf("shell approval state = %q, want %q", current.ShellApprovalState, runtimecore.ShellApprovalStateRunning)
+	}
+	if current.ShellForegroundDeadline.IsZero() {
+		t.Fatal("shell start did not establish foreground deadline")
+	}
+}
+
+func TestShellRejectedResultDoesNotBecomeSyntheticRecovery(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "opened")
+	rejected := &agentv1.ExecClientMessage{
+		Id:     pending.MessageID,
+		ExecId: pending.ExecID,
+		Message: &agentv1.ExecClientMessage_ShellStream{
+			ShellStream: &agentv1.ShellStream{
+				Event: &agentv1.ShellStream_Rejected{Rejected: &agentv1.ShellRejected{Reason: "user skipped"}},
+			},
+		},
+	}
+
+	if err := service.handleExecResult(InboundIntent{RequestID: stream.RequestID, ExecClientMessage: rejected}); err != nil {
+		t.Fatalf("shell rejected error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); found {
+		t.Fatal("rejected shell remained pending")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("rejected completion count = %d, want 1", completions)
+	}
+	if shellHistoryContains(stream, "<shell-incomplete>") {
+		t.Fatal("rejected shell emitted synthetic recovery")
+	}
+}
+
+func TestShellTransportRecoveryDoesNotCloseWhileAwaitingApproval(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "opened")
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("approval transport recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); !found {
+		t.Fatal("transport close completed shell without approval")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 0 {
+		t.Fatalf("approval transport completion count = %d, want 0", completions)
+	}
+}
+
+func TestShellForegroundTimeoutDuration(t *testing.T) {
+	testCases := []struct {
+		name string
+		args string
+		want time.Duration
+	}{
+		{name: "default", args: `{}`, want: 30 * time.Second},
+		{name: "explicit foreground timeout", args: `{"block_until_ms":60000}`, want: time.Minute},
+		{name: "background immediately", args: `{"block_until_ms":0}`, want: 0},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := shellForegroundTimeoutDuration([]byte(testCase.args)); got != testCase.want {
+				t.Fatalf("shellForegroundTimeoutDuration(%s) = %s, want %s", testCase.args, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestInitializePendingShellSetsDeadlineAfterForegroundTimeoutAndGrace(t *testing.T) {
+	openedAt := time.Now().UTC().Add(-time.Second)
+	pending := initializePendingExecForTracking(runtimecore.PendingExec{
+		ExecID:             "exec-shell-1",
+		ExecKind:           "shell",
+		OpenedAt:           openedAt,
+		ArgsJSON:           []byte(`{"block_until_ms":30000}`),
+		StreamState:        "started",
+		ShellApprovalState: runtimecore.ShellApprovalStateRunning,
+	})
+	wantDeadline := openedAt.Add(30*time.Second + shellTerminalRecoveryGrace)
+	if !pending.ShellForegroundDeadline.Equal(wantDeadline) {
+		t.Fatalf("foreground deadline = %s, want %s", pending.ShellForegroundDeadline, wantDeadline)
+	}
+	if !pending.LastShellActivityAt.Equal(openedAt) {
+		t.Fatalf("last shell activity = %s, want %s", pending.LastShellActivityAt, openedAt)
+	}
+}
+
+func TestShellStreamCloseMarksPendingTransportClosedOnce(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "opened")
+	streamClose := shellStreamClose(pending.MessageID)
+
+	if err := service.handleExecControl(InboundIntent{RequestID: stream.RequestID, ExecClientControlMessage: streamClose}); err != nil {
+		t.Fatalf("first stream close error = %v", err)
+	}
+	current, found := snapshotPendingExec(stream, pending.ExecID)
+	if !found || current.StreamState != "transport_closed" || !current.ShellRecoveryScheduled {
+		t.Fatalf("first stream close pending = %#v, want transport_closed recovery", current)
+	}
+
+	if err := service.handleExecControl(InboundIntent{RequestID: stream.RequestID, ExecClientControlMessage: streamClose}); err != nil {
+		t.Fatalf("duplicate stream close error = %v", err)
+	}
+	current, found = snapshotPendingExec(stream, pending.ExecID)
+	if !found || !current.ShellRecoveryScheduled {
+		t.Fatalf("duplicate stream close changed pending state = %#v", current)
+	}
+}
+
+func TestShellExitAfterStreamCloseWinsGracePeriodRecovery(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "streaming")
+	pending.StdoutBuffer = "completed stdout"
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+
+	if err := service.handleExecControl(InboundIntent{RequestID: stream.RequestID, ExecClientControlMessage: shellStreamClose(pending.MessageID)}); err != nil {
+		t.Fatalf("stream close error = %v", err)
+	}
+	if err := service.handleExecResult(InboundIntent{RequestID: stream.RequestID, ExecClientMessage: shellExitMessage(pending, 0)}); err != nil {
+		t.Fatalf("late exit error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); found {
+		t.Fatal("late exit left Shell pending")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("completion count = %d, want 1", completions)
+	}
+	if !shellHistoryContains(stream, "completed stdout") {
+		t.Fatal("terminal Shell output was not persisted")
+	}
+	if shellHistoryContains(stream, "<shell-incomplete>") {
+		t.Fatal("late exit incorrectly persisted synthetic Shell recovery")
+	}
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("recovery after terminal exit error = %v", err)
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("completion count after recovery = %d, want 1", completions)
+	}
+}
+
+func TestShellTransportCloseRecoveryCompletesToolExactlyOnce(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "transport_closed")
+	pending.StdoutBuffer = "partial stdout"
+	pending.StderrBuffer = "partial stderr"
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("transport-close recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); found {
+		t.Fatal("transport-close recovery left the shell pending")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("completion count = %d, want 1", completions)
+	}
+	if !shellHistoryContains(stream, "The shell transport closed before a terminal event arrived.") {
+		t.Fatal("synthetic shell result was not persisted")
+	}
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("duplicate recovery error = %v", err)
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("duplicate recovery completion count = %d, want 1", completions)
+	}
+}
+
+func TestShellForegroundRecoveryCompletesAfterDeadline(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "streaming")
+	pending.ShellForegroundDeadline = time.Now().UTC().Add(-time.Millisecond)
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonForegroundDeadline); err != nil {
+		t.Fatalf("foreground recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); found {
+		t.Fatal("foreground recovery left the shell pending")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("completion count = %d, want 1", completions)
+	}
+	if !shellHistoryContains(stream, "The foreground wait window expired after 30000ms") {
+		t.Fatal("foreground recovery result did not retain timeout reason")
+	}
+}
+
+func TestShellForegroundRecoveryDoesNotCloseBeforeDeadline(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "streaming")
+	pending.ShellForegroundDeadline = time.Now().UTC().Add(time.Minute)
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonForegroundDeadline); err != nil {
+		t.Fatalf("recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); !found {
+		t.Fatal("recovery completed shell before its foreground deadline")
+	}
+}
+
+func TestForegroundRecoveryNeverClosesShellAfterTerminalEvent(t *testing.T) {
+	terminalStates := []string{"exited", "backgrounded", "rejected", "permission_denied"}
+	for _, state := range terminalStates {
+		t.Run(state, func(t *testing.T) {
+			service, stream, pending := testShellRecoveryFixture(t, state)
+			pending.ShellForegroundDeadline = time.Now().UTC().Add(-time.Second)
+			stream.mu.Lock()
+			stream.PendingExecs[pending.ExecID] = pending
+			stream.mu.Unlock()
+
+			if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonForegroundDeadline); err != nil {
+				t.Fatalf("recovery error = %v", err)
+			}
+			if _, found := snapshotPendingExec(stream, pending.ExecID); !found {
+				t.Fatalf("recovery incorrectly completed %q terminal state", state)
+			}
+		})
+	}
+}
+
+func TestShellTransportRecoverySkipsTerminalStateAfterStreamClose(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "transport_closed")
+	stream.mu.Lock()
+	current := stream.PendingExecs[pending.ExecID]
+	current.StreamState = "exited"
+	stream.PendingExecs[pending.ExecID] = current
+	stream.mu.Unlock()
+
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("transport recovery error = %v", err)
+	}
+	if _, found := snapshotPendingExec(stream, pending.ExecID); !found {
+		t.Fatal("transport recovery incorrectly completed a late terminal state")
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 0 {
+		t.Fatalf("completion count = %d, want 0 before terminal result handling", completions)
+	}
+}
+
+func TestShellLateControlAndResultAfterRecoveryAreIgnored(t *testing.T) {
+	service, stream, pending := testShellRecoveryFixture(t, "transport_closed")
+	if err := service.recoverShellWithoutTerminalIfNeeded(stream, pending.ExecID, pending.MessageID, shellRecoveryReasonTransportClosed); err != nil {
+		t.Fatalf("recovery error = %v", err)
+	}
+
+	if err := service.handleExecControl(InboundIntent{RequestID: stream.RequestID, ExecClientControlMessage: shellStreamClose(pending.MessageID)}); err != nil {
+		t.Fatalf("late stream close error = %v, want ignored", err)
+	}
+	if err := service.handleExecResult(InboundIntent{RequestID: stream.RequestID, ExecClientMessage: &agentv1.ExecClientMessage{Id: pending.MessageID, ExecId: pending.ExecID}}); err != nil {
+		t.Fatalf("late shell result error = %v, want ignored", err)
+	}
+	if completions := shellCompletionCount(stream, pending.ToolCallID); completions != 1 {
+		t.Fatalf("completion count after late events = %d, want 1", completions)
+	}
+}
+
+func testShellRecoveryFixture(t *testing.T, state string) (*Service, *ActiveStream, runtimecore.PendingExec) {
+	t.Helper()
+	broker := NewStreamBroker()
+	stream, err := broker.OpenStream("request-shell-1", "conversation-shell-1", 1, "model", "model", agentv1.AgentMode_AGENT_MODE_AGENT, "shell test")
+	if err != nil {
+		t.Fatalf("OpenStream() error = %v", err)
+	}
+	service := &Service{
+		broker:     broker,
+		projector:  NewHistoryProjector(),
+		execBridge: execbridge.NewBridge(),
+	}
+	if err := service.replaceCheckpointConversation(stream, testConversation(nil)); err != nil {
+		t.Fatalf("replaceCheckpointConversation() error = %v", err)
+	}
+	pending := initializePendingExecForTracking(runtimecore.PendingExec{
+		MessageID:   71,
+		ExecID:      "exec-shell-71",
+		ExecKind:    "shell",
+		ToolCallID:  "tool-shell-71",
+		ModelCallID: "model-call-71",
+		ArgsJSON:    []byte(`{"command":"go test ./...","block_until_ms":30000}`),
+		OpenedAt:    time.Now().UTC().Add(-time.Second),
+		StreamState: state,
+	})
+	if state == "transport_closed" {
+		pending.ShellApprovalState = runtimecore.ShellApprovalStateRunning
+	}
+	stream.mu.Lock()
+	stream.PendingExecs[pending.ExecID] = pending
+	stream.mu.Unlock()
+	return service, stream, pending
+}
+
+func shellStreamClose(messageID uint32) *agentv1.ExecClientControlMessage {
+	return &agentv1.ExecClientControlMessage{
+		Message: &agentv1.ExecClientControlMessage_StreamClose{
+			StreamClose: &agentv1.ExecClientStreamClose{Id: messageID},
+		},
+	}
+}
+
+func shellExitMessage(pending runtimecore.PendingExec, exitCode uint32) *agentv1.ExecClientMessage {
+	return &agentv1.ExecClientMessage{
+		Id:     pending.MessageID,
+		ExecId: pending.ExecID,
+		Message: &agentv1.ExecClientMessage_ShellStream{
+			ShellStream: &agentv1.ShellStream{
+				Event: &agentv1.ShellStream_Exit{
+					Exit: &agentv1.ShellStreamExit{Code: exitCode},
+				},
+			},
+		},
+	}
+}
+
+func shellCompletionCount(stream *ActiveStream, toolCallID string) int {
+	if stream == nil {
+		return 0
+	}
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	count := 0
+	for _, event := range stream.Backlog {
+		completed := event.Message.GetInteractionUpdate().GetToolCallCompleted()
+		if completed != nil && completed.GetCallId() == toolCallID {
+			count++
+		}
+	}
+	return count
+}
+
+func shellHistoryContains(stream *ActiveStream, needle string) bool {
+	if stream == nil {
+		return false
+	}
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	if stream.CheckpointConversation == nil {
+		return false
+	}
+	for _, entry := range stream.CheckpointConversation.Entries {
+		if strings.Contains(string(entry.Payload), needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this fixes

When Cursor shows a Shell command approval dialog, the command has not started yet—it is waiting for the user to click **Run** or **Skip**.

Previously, the forwarder could start its Shell timeout/recovery logic before the user made that choice. If the approval dialog stayed open for too long, it could incorrectly mark the Shell tool as incomplete or finished, even though the command had never run.

## What changed

This PR distinguishes between:

- **Waiting for approval**: the command is shown in Cursor but has not started.
- **Running**: the client has sent a Shell `start`, `stdout`, or `stderr` event.

Shell timeout and recovery now begin only after the command is actually running.

If the user skips the command, it is still completed normally. If the Shell is running and its stream closes without a terminal event, the existing recovery behavior remains unchanged.

## Tests

Added coverage for:

- waiting at the approval dialog without timing out;
- starting recovery after Shell execution begins;
- skipping a command;
- transport-close and foreground-timeout recovery.

## Validation

```text
go test ./internal/backend/forwarder
```

This PR is intentionally limited to Shell approval and recovery behavior.