### PR TITLE
fix(build): add configurable Windows and macOS release signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,32 @@ task dev
 task build
 ```
 
+### 发布签名
+
+默认构建不需要证书，产物仅用于本地测试。公开发布前必须在 CI 或受控发布机中配置下列变量，切勿把证书密码、私钥或 Apple 凭据提交到仓库：
+
+```bash
+# Windows：当前用户证书存储中的代码签名证书 SHA-1 指纹
+WINDOWS_SIGN_CERT_SHA1=0123456789ABCDEF... \
+WINDOWS_SIGN_TIMESTAMP_URL=https://timestamp.digicert.com \
+task build:windows:amd64
+
+# macOS：Developer ID 证书名称和预先创建的 notarytool Keychain profile
+MACOS_SIGN_IDENTITY='Developer ID Application: Example, Inc. (TEAMID)' \
+MACOS_NOTARY_PROFILE='notary-profile' \
+task build:darwin:arm64
+```
+
+Windows PowerShell 可使用：
+
+```powershell
+$env:WINDOWS_SIGN_CERT_SHA1 = '0123456789ABCDEF...'
+$env:WINDOWS_SIGN_TIMESTAMP_URL = 'https://timestamp.digicert.com'
+task build:windows:amd64
+```
+
+Windows 默认使用 NSIS。`FORMAT=msix` 仅在所安装的 Wails CLI 支持 `wails3 tool msix` 时可用；MSIX 的 Publisher 必须与签名证书 Subject 完全一致。
+
 ## 项目结构
 
 ```

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -29,6 +29,32 @@ task dev
 task build
 ```
 
+### Release signing
+
+Default builds do not require a certificate and are for local testing only. Before public distribution, configure the following variables in CI or on a controlled release machine. Never commit certificate passwords, private keys, or Apple credentials:
+
+```bash
+# Windows: SHA-1 thumbprint of a code-signing certificate in the current-user store
+WINDOWS_SIGN_CERT_SHA1=0123456789ABCDEF... \
+WINDOWS_SIGN_TIMESTAMP_URL=https://timestamp.digicert.com \
+task build:windows:amd64
+
+# macOS: Developer ID identity and a preconfigured notarytool Keychain profile
+MACOS_SIGN_IDENTITY='Developer ID Application: Example, Inc. (TEAMID)' \
+MACOS_NOTARY_PROFILE='notary-profile' \
+task build:darwin:arm64
+```
+
+On Windows PowerShell, use:
+
+```powershell
+$env:WINDOWS_SIGN_CERT_SHA1 = '0123456789ABCDEF...'
+$env:WINDOWS_SIGN_TIMESTAMP_URL = 'https://timestamp.digicert.com'
+task build:windows:amd64
+```
+
+Windows defaults to NSIS. `FORMAT=msix` is available only when the installed Wails CLI supports `wails3 tool msix`; the MSIX Publisher must exactly match the signing certificate Subject.
+
 ## Project Structure
 
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,10 @@ vars:
   CURRENT_DARWIN_NAME: '{{if eq ARCH "arm64"}}macos-arm64{{else}}macos-intel{{end}}'
   CURRENT_LINUX_ARCH: "amd64"
   CURRENT_LINUX_NAME: "linux-amd64"
+  WINDOWS_SIGN_CERT_SHA1: '{{.WINDOWS_SIGN_CERT_SHA1 | default ""}}'
+  WINDOWS_SIGN_TIMESTAMP_URL: '{{.WINDOWS_SIGN_TIMESTAMP_URL | default "https://timestamp.digicert.com"}}'
+  MACOS_SIGN_IDENTITY: '{{.MACOS_SIGN_IDENTITY | default ""}}'
+  MACOS_NOTARY_PROFILE: '{{.MACOS_NOTARY_PROFILE | default ""}}'
 
 tasks:
   build:

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -199,18 +199,27 @@ tasks:
       - cp build/darwin/icons.icns "{{.BIN_DIR}}/{{.APP_BUNDLE}}/Contents/Resources"
       - cp "{{.BINARY_PATH}}" "{{.BIN_DIR}}/{{.APP_BUNDLE}}/Contents/MacOS/{{.EXECUTABLE_NAME}}"
       - cp build/darwin/Info.plist "{{.BIN_DIR}}/{{.APP_BUNDLE}}/Contents"
-      - task: codesign:adhoc
+      - /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString {{.APP_VERSION}}" "{{.BIN_DIR}}/{{.APP_BUNDLE}}/Contents/Info.plist"
+      - /usr/libexec/PlistBuddy -c "Set :CFBundleVersion {{.APP_VERSION}}" "{{.BIN_DIR}}/{{.APP_BUNDLE}}/Contents/Info.plist"
+      - task: codesign:app
         vars:
           APP_BUNDLE:
             ref: .APP_BUNDLE
 
-  codesign:adhoc:
-    summary: 使用临时签名（开发测试）
+  codesign:app:
+    summary: 使用 Developer ID 签名 macOS 应用；未配置时仅使用 ad-hoc 签名
     internal: true
     vars:
       APP_BUNDLE: '{{.APP_BUNDLE | default (printf "%s.app" .APP_NAME)}}'
     cmds:
-      - codesign --force --deep --sign - "{{.BIN_DIR}}/{{.APP_BUNDLE}}"
+      - |
+        {{if .MACOS_SIGN_IDENTITY}}
+        codesign --force --deep --options runtime --sign "{{.MACOS_SIGN_IDENTITY}}" "{{.BIN_DIR}}/{{.APP_BUNDLE}}"
+        {{else}}
+        echo "未设置 MACOS_SIGN_IDENTITY，使用 ad-hoc 签名，仅可用于本地测试。"
+        codesign --force --deep --sign - "{{.BIN_DIR}}/{{.APP_BUNDLE}}"
+        {{end}}
+      - codesign --verify --deep --strict --verbose=2 "{{.BIN_DIR}}/{{.APP_BUNDLE}}"
 
   create:dmg:
     summary: 生成 macOS DMG 包（优先使用 create-dmg，不存在时回退 hdiutil）
@@ -236,6 +245,32 @@ tasks:
           hdiutil create -volname "{{.APP_NAME}}" -srcfolder "{{.STAGING_DIR}}" -ov -format UDZO "{{.BIN_DIR}}/{{.DMG_NAME}}"
         fi
       - rm -rf "{{.STAGING_DIR}}"
+      - task: sign:notarize:dmg
+        vars:
+          DMG_NAME:
+            ref: .DMG_NAME
+
+  sign:notarize:dmg:
+    summary: 对 DMG 签名并在配置 notary profile 时提交公证
+    internal: true
+    vars:
+      DMG_NAME: '{{.DMG_NAME | default (printf "%s.dmg" .APP_NAME)}}'
+    cmds:
+      - |
+        {{if .MACOS_SIGN_IDENTITY}}
+        codesign --force --sign "{{.MACOS_SIGN_IDENTITY}}" "{{.BIN_DIR}}/{{.DMG_NAME}}"
+        codesign --verify --verbose=2 "{{.BIN_DIR}}/{{.DMG_NAME}}"
+        {{else}}
+        echo "未设置 MACOS_SIGN_IDENTITY，跳过 DMG 签名和公证。"
+        {{end}}
+      - |
+        {{if .MACOS_NOTARY_PROFILE}}
+        xcrun notarytool submit "{{.BIN_DIR}}/{{.DMG_NAME}}" --keychain-profile "{{.MACOS_NOTARY_PROFILE}}" --wait
+        xcrun stapler staple "{{.BIN_DIR}}/{{.DMG_NAME}}"
+        xcrun stapler validate "{{.BIN_DIR}}/{{.DMG_NAME}}"
+        {{else}}
+        echo "未设置 MACOS_NOTARY_PROFILE，跳过 macOS 公证。"
+        {{end}}
 
   create:archive:
     summary: 生成 macOS updater tar.gz 归档

--- a/build/windows/Taskfile.yml
+++ b/build/windows/Taskfile.yml
@@ -43,6 +43,10 @@ tasks:
           ARCH:
             ref: .ARCH
       - go build {{.BUILD_FLAGS}} -o "{{.OUTPUT}}"
+      - task: sign:authenticode
+        vars:
+          TARGET:
+            ref: .OUTPUT
       - cmd: powershell Remove-item *.syso
         platforms: [windows]
       - cmd: rm -f *.syso
@@ -89,13 +93,19 @@ tasks:
         {{else}}
         makensis -DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" project.nsi
         {{end}}
+      - task: sign:authenticode
+        vars:
+          TARGET: '{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}-{{.ARCH}}-installer.exe'
     vars:
       ARCH: '{{.ARCH | default ARCH}}'
       ARG_FLAG: '{{if eq .ARCH "amd64"}}AMD64{{else}}ARM64{{end}}'
 
   create:msix:package:
-    summary: 生成 MSIX 安装包
+    summary: 生成 MSIX 安装包（需要包含 msix 工具的 Wails CLI）
     internal: true
+    preconditions:
+      - sh: 'wails3 tool --help 2>&1 | grep -Eq "^[[:space:]]*msix([[:space:]]|$)"'
+        msg: "当前 Wails CLI 不支持 'wails3 tool msix'。请使用 NSIS（默认格式），或升级到包含 MSIX 工具的 Wails CLI 后再执行 FORMAT=msix。"
     deps:
       - task: build
         vars:
@@ -117,6 +127,25 @@ tasks:
       CERT_PATH: '{{.CERT_PATH | default ""}}'
       PUBLISHER: '{{.PUBLISHER | default ""}}'
       USE_MSIX_TOOL: '{{.USE_MSIX_TOOL | default "false"}}'
+
+  sign:authenticode:
+    summary: 使用证书存储中的 SHA-1 指纹签名 Windows PE 产物
+    internal: true
+    vars:
+      TARGET: '{{.TARGET}}'
+    preconditions:
+      - sh: 'test -n "{{.TARGET}}"'
+        msg: "Windows 签名目标不能为空。"
+      - sh: 'test -z "{{.WINDOWS_SIGN_CERT_SHA1}}" || command -v signtool >/dev/null 2>&1'
+        msg: "配置 WINDOWS_SIGN_CERT_SHA1 后必须安装 signtool。"
+    cmds:
+      - |
+        {{if .WINDOWS_SIGN_CERT_SHA1}}
+        signtool sign /sha1 "{{.WINDOWS_SIGN_CERT_SHA1}}" /fd SHA256 /tr "{{.WINDOWS_SIGN_TIMESTAMP_URL}}" /td SHA256 "{{.TARGET}}"
+        signtool verify /pa /v "{{.TARGET}}"
+        {{else}}
+        echo "未设置 WINDOWS_SIGN_CERT_SHA1，跳过 Windows 签名：{{.TARGET}}"
+        {{end}}
 
   create:zip:
     summary: 生成 Windows ZIP 包（包含 exe 与 certs）


### PR DESCRIPTION
## Summary
- add optional Authenticode signing and verification for Windows executable and NSIS installer
- add configurable Developer ID signing, hardened runtime, DMG signing, and notarization hooks for macOS
- derive macOS bundle versions from `APP_VERSION`
- fail early for `FORMAT=msix` when the installed Wails CLI does not expose an MSIX tool
- document release signing variables for Bash and PowerShell

## Validation
- `go test ./scripts/release`
- `go vet ./scripts/release`
- `task --dry build:windows:amd64`
- `task --dry build:darwin:arm64`
- verified the MSIX availability precondition against Wails v3.0.0-beta.10

## Notes
A local Windows package build reached `wails3 generate bindings` but was blocked by host virtual-memory exhaustion (`VirtualAlloc errno=1455`). No signed or notarized artifact was produced locally because no release certificate or Apple notary profile was supplied; macOS packaging also requires a macOS runner.