### PR TITLE
feat(rules): persist and inject global Cursor rules

### DIFF
--- a/server/src/app.rs
+++ b/server/src/app.rs
@@ -34,8 +34,9 @@ impl App {
                 .listen_addr
                 .set_port(store.port_settings().await?.service_port);
         }
+        let global_rules_dir = crate::config::global_rules_dir()?;
         let assets = PromptAssets::embedded()?;
-        let compiler = PromptCompiler::new(assets);
+        let compiler = PromptCompiler::with_global_rules_dir(assets, global_rules_dir);
         let provider = std::sync::Arc::new(ProviderRouter::new(
             store.clone(),
             config.provider_request_timeout,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -7,10 +7,19 @@ use crate::{Error, Result};
 
 const DATA_DIR_NAME: &str = ".cursor-byok-v3";
 const DATABASE_FILE_NAME: &str = "cursor-byok.db";
+const RULES_DIR_NAME: &str = "rules";
 
 pub fn managed_data_dir() -> Result<PathBuf> {
     let home_dir = dirs::home_dir()
         .ok_or_else(|| Error::Config("cannot resolve user home directory".into()))?;
+    managed_data_dir_in(&home_dir)
+}
+
+pub fn global_rules_dir() -> Result<PathBuf> {
+    Ok(managed_data_dir()?.join(RULES_DIR_NAME).join("global"))
+}
+
+fn managed_data_dir_in(home_dir: &std::path::Path) -> Result<PathBuf> {
     let data_dir = home_dir.join(DATA_DIR_NAME);
     fs::create_dir_all(&data_dir)?;
     #[cfg(unix)]

--- a/server/src/cursor/handlers.rs
+++ b/server/src/cursor/handlers.rs
@@ -13,7 +13,7 @@ use crate::{
         observability::CursorTraceRecorder,
         proto::{agent::v1 as agent, aiserver::v1 as ai},
         proxy::{self, CursorProxy},
-        run_sse, tab,
+        rules, run_sse, tab,
     },
     cursor::{CursorParent, CursorSessionRegistry},
     Result,
@@ -64,6 +64,19 @@ fn router_with_proxy(registry: CursorSessionRegistry, proxy: CursorProxy) -> Rou
         .route(
             "/aiserver.v1.DashboardService/GetUsageLimitStatusAndActiveGrants",
             post(account::usage_limit_status),
+        )
+        .route("/aiserver.v1.AiService/KnowledgeBaseAdd", post(rules::add))
+        .route(
+            "/aiserver.v1.AiService/KnowledgeBaseList",
+            post(rules::list),
+        )
+        .route(
+            "/aiserver.v1.AiService/KnowledgeBaseUpdate",
+            post(rules::update),
+        )
+        .route(
+            "/aiserver.v1.AiService/KnowledgeBaseRemove",
+            post(rules::remove),
         )
         .route(
             analytics::BOOTSTRAP_STATSIG_PATH,

--- a/server/src/cursor/handlers.rs
+++ b/server/src/cursor/handlers.rs
@@ -79,6 +79,10 @@ fn router_with_proxy(registry: CursorSessionRegistry, proxy: CursorProxy) -> Rou
             post(rules::remove),
         )
         .route(
+            "/aiserver.v1.AiService/FetchRelevantKnowledgeForConversation",
+            post(rules::relevant),
+        )
+        .route(
             analytics::BOOTSTRAP_STATSIG_PATH,
             post(analytics::bootstrap_statsig),
         )

--- a/server/src/cursor/mod.rs
+++ b/server/src/cursor/mod.rs
@@ -19,6 +19,7 @@ pub mod prompting;
 pub mod proto;
 pub mod proxy;
 pub mod request;
+mod rules;
 pub mod run_sse;
 pub mod session;
 pub mod sessions;

--- a/server/src/cursor/prompting/compiler.rs
+++ b/server/src/cursor/prompting/compiler.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use crate::{
+    cursor::rules,
     model::{ModelSpec, PromptSpec, ToolDefinition},
     Error, Result,
 };
@@ -10,11 +12,22 @@ use super::{assets::runtime_expression, Mode, PromptAssets};
 #[derive(Clone)]
 pub struct PromptCompiler {
     assets: PromptAssets,
+    global_rules_dir: Option<PathBuf>,
 }
 
 impl PromptCompiler {
     pub fn new(assets: PromptAssets) -> Self {
-        Self { assets }
+        Self {
+            assets,
+            global_rules_dir: None,
+        }
+    }
+
+    pub fn with_global_rules_dir(assets: PromptAssets, directory: impl Into<PathBuf>) -> Self {
+        Self {
+            assets,
+            global_rules_dir: Some(directory.into()),
+        }
     }
 
     pub fn runtime_message(&self, mode: Mode, values: &BTreeMap<&str, String>) -> Result<String> {
@@ -39,14 +52,27 @@ impl PromptCompiler {
             .display_name
             .as_deref()
             .unwrap_or(model.model_id.as_str());
+        let instructions = self
+            .assets
+            .mode(mode)
+            .prompt
+            .replace("{{FAKE_MODEL_NAME}}", fake_model_name);
         Ok(PromptSpec {
-            instructions: self
-                .assets
-                .mode(mode)
-                .prompt
-                .replace("{{FAKE_MODEL_NAME}}", fake_model_name),
+            instructions: self.append_global_rules(instructions)?,
             tools,
         })
+    }
+
+    fn append_global_rules(&self, mut instructions: String) -> Result<String> {
+        let Some(directory) = &self.global_rules_dir else {
+            return Ok(instructions);
+        };
+        let rules = rules::system_prompt_section(directory.clone())?;
+        if !rules.is_empty() {
+            instructions.push_str("\n\n");
+            instructions.push_str(&rules);
+        }
+        Ok(instructions)
     }
 
     fn tools(&self, mode: Mode, suppress_subagent_progress: bool) -> Vec<ToolDefinition> {

--- a/server/src/cursor/rules.rs
+++ b/server/src/cursor/rules.rs
@@ -18,6 +18,10 @@ struct KnowledgeBaseAddRequest {
     knowledge: String,
     #[prost(string, tag = "2")]
     title: String,
+    #[prost(string, tag = "3")]
+    _git_origin: String,
+    #[prost(string, optional, tag = "4")]
+    _composer_id: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -32,6 +36,8 @@ struct KnowledgeBaseAddResponse {
 struct KnowledgeBaseListRequest {
     #[prost(int32, optional, tag = "1")]
     limit: Option<i32>,
+    #[prost(string, optional, tag = "2")]
+    _git_origin: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -82,6 +88,38 @@ struct KnowledgeBaseRemoveRequest {
 struct KnowledgeBaseRemoveResponse {
     #[prost(bool, tag = "1")]
     success: bool,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct FetchRelevantKnowledgeForConversationRequest {
+    #[prost(string, tag = "1")]
+    _request_id: String,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    _conversation: Vec<Vec<u8>>,
+    #[prost(string, optional, tag = "3")]
+    _git_origin: Option<String>,
+    #[prost(int32, optional, tag = "4")]
+    limit: Option<i32>,
+    #[prost(string, repeated, tag = "5")]
+    _tagged_filenames: Vec<String>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct FetchRelevantKnowledgeForConversationResponse {
+    #[prost(message, repeated, tag = "1")]
+    knowledge_items: Vec<RelevantKnowledgeItem>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct RelevantKnowledgeItem {
+    #[prost(string, tag = "1")]
+    title: String,
+    #[prost(string, tag = "2")]
+    knowledge: String,
+    #[prost(string, tag = "3")]
+    knowledge_id: String,
+    #[prost(bool, tag = "4")]
+    is_generated: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -146,6 +184,35 @@ pub async fn list(request: Request<Body>) -> Result<Response<Body>> {
             })
             .collect(),
     })
+}
+
+pub async fn relevant(request: Request<Body>) -> Result<Response<Body>> {
+    let request = decode::<FetchRelevantKnowledgeForConversationRequest>(request).await?;
+    let store = RuleStore::open(config::global_rules_dir()?)?;
+    let rules = store.list()?;
+    proto(&FetchRelevantKnowledgeForConversationResponse {
+        knowledge_items: relevant_knowledge_items(rules, request.limit),
+    })
+}
+
+fn relevant_knowledge_items(rules: Vec<Rule>, limit: Option<i32>) -> Vec<RelevantKnowledgeItem> {
+    let limit = limit
+        .filter(|limit| *limit >= 0)
+        .map(|limit| limit as usize);
+    rules
+        .into_iter()
+        .take(limit.unwrap_or(usize::MAX))
+        .map(relevant_knowledge_item)
+        .collect()
+}
+
+fn relevant_knowledge_item(rule: Rule) -> RelevantKnowledgeItem {
+    RelevantKnowledgeItem {
+        title: rule.id.clone(),
+        knowledge: rule.knowledge,
+        knowledge_id: rule.id,
+        is_generated: false,
+    }
 }
 
 pub async fn update(request: Request<Body>) -> Result<Response<Body>> {
@@ -304,6 +371,45 @@ fn valid_id(id: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relevant_knowledge_is_global_across_git_origins() {
+        let rules = vec![
+            Rule {
+                id: "first-rule".into(),
+                knowledge: "always write tests".into(),
+                created_at: "2026-08-25T00:00:00Z".into(),
+            },
+            Rule {
+                id: "second-rule".into(),
+                knowledge: "keep modules small".into(),
+                created_at: "2026-08-25T00:01:00Z".into(),
+            },
+        ];
+
+        let project_a = relevant_knowledge_items(rules.clone(), Some(10));
+        let project_b = relevant_knowledge_items(rules, Some(10));
+
+        assert_eq!(project_a, project_b);
+        assert_eq!(
+            project_b
+                .into_iter()
+                .map(|item| item.knowledge_id)
+                .collect::<Vec<_>>(),
+            vec!["first-rule", "second-rule"]
+        );
+    }
+
+    #[test]
+    fn relevant_knowledge_honors_a_non_negative_limit() {
+        let rules = vec![Rule {
+            id: "rule-id".into(),
+            knowledge: "always write tests".into(),
+            created_at: "2026-08-25T00:00:00Z".into(),
+        }];
+
+        assert!(relevant_knowledge_items(rules, Some(0)).is_empty());
+    }
 
     #[tokio::test]
     async fn rule_response_uses_raw_protobuf_like_the_cursor_connect_handler() {

--- a/server/src/cursor/rules.rs
+++ b/server/src/cursor/rules.rs
@@ -1,0 +1,347 @@
+use std::{fs, path::PathBuf};
+
+use axum::{
+    body::Body,
+    http::{header, HeaderValue, Request, Response},
+};
+use chrono::{DateTime, Utc};
+use prost::Message;
+use uuid::Uuid;
+
+use crate::{config, cursor::connect, Error, Result};
+
+const RULE_EXTENSION: &str = "md";
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseAddRequest {
+    #[prost(string, tag = "1")]
+    knowledge: String,
+    #[prost(string, tag = "2")]
+    title: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseAddResponse {
+    #[prost(bool, tag = "1")]
+    success: bool,
+    #[prost(string, tag = "2")]
+    id: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseListRequest {
+    #[prost(int32, optional, tag = "1")]
+    limit: Option<i32>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseListResponse {
+    #[prost(message, repeated, tag = "2")]
+    all_results: Vec<KnowledgeBaseListItem>,
+    #[prost(bool, tag = "1")]
+    success: bool,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseListItem {
+    #[prost(string, tag = "1")]
+    id: String,
+    #[prost(string, tag = "2")]
+    knowledge: String,
+    #[prost(string, tag = "3")]
+    title: String,
+    #[prost(string, tag = "4")]
+    created_at: String,
+    #[prost(bool, tag = "5")]
+    is_generated: bool,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseUpdateRequest {
+    #[prost(string, tag = "1")]
+    id: String,
+    #[prost(string, tag = "2")]
+    knowledge: String,
+    #[prost(string, tag = "3")]
+    title: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseUpdateResponse {
+    #[prost(bool, tag = "1")]
+    success: bool,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseRemoveRequest {
+    #[prost(string, tag = "1")]
+    id: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct KnowledgeBaseRemoveResponse {
+    #[prost(bool, tag = "1")]
+    success: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Rule {
+    id: String,
+    knowledge: String,
+    created_at: String,
+}
+
+pub(crate) fn system_prompt_section(path: PathBuf) -> Result<String> {
+    let store = RuleStore::open(path)?;
+    let rules = store.list()?;
+    let mut section = String::from(
+        "<shared_user_rules description=\"These shared local rules apply to every conversation. Follow them when relevant.\">",
+    );
+    for rule in rules {
+        let content = rule_content(&rule.knowledge);
+        if content.is_empty() {
+            continue;
+        }
+        section.push_str("\n<rule file=\"");
+        section.push_str(&escape_xml(&format!("{}.{}", rule.id, RULE_EXTENSION)));
+        section.push_str("\">\n");
+        section.push_str(&escape_xml(content));
+        section.push_str("\n</rule>");
+    }
+    if section.lines().count() == 1 {
+        return Ok(String::new());
+    }
+    section.push_str("\n</shared_user_rules>");
+    Ok(section)
+}
+
+pub async fn add(request: Request<Body>) -> Result<Response<Body>> {
+    let request = decode::<KnowledgeBaseAddRequest>(request).await?;
+    let knowledge = required_knowledge(&request.knowledge)?;
+    let store = RuleStore::open(config::global_rules_dir()?)?;
+    let rule = store.add(knowledge)?;
+    proto(&KnowledgeBaseAddResponse {
+        success: true,
+        id: rule.id,
+    })
+}
+
+pub async fn list(request: Request<Body>) -> Result<Response<Body>> {
+    let request = decode::<KnowledgeBaseListRequest>(request).await?;
+    let store = RuleStore::open(config::global_rules_dir()?)?;
+    let mut rules = store.list()?;
+    if let Some(limit) = request.limit.filter(|limit| *limit >= 0) {
+        rules.truncate(limit as usize);
+    }
+    proto(&KnowledgeBaseListResponse {
+        success: true,
+        all_results: rules
+            .into_iter()
+            .map(|rule| KnowledgeBaseListItem {
+                title: rule.id.clone(),
+                id: rule.id,
+                knowledge: rule.knowledge,
+                created_at: rule.created_at,
+                is_generated: false,
+            })
+            .collect(),
+    })
+}
+
+pub async fn update(request: Request<Body>) -> Result<Response<Body>> {
+    let request = decode::<KnowledgeBaseUpdateRequest>(request).await?;
+    let knowledge = required_knowledge(&request.knowledge)?;
+    let store = RuleStore::open(config::global_rules_dir()?)?;
+    store.update(&request.id, knowledge)?;
+    proto(&KnowledgeBaseUpdateResponse { success: true })
+}
+
+pub async fn remove(request: Request<Body>) -> Result<Response<Body>> {
+    let request = decode::<KnowledgeBaseRemoveRequest>(request).await?;
+    let store = RuleStore::open(config::global_rules_dir()?)?;
+    store.remove(&request.id)?;
+    proto(&KnowledgeBaseRemoveResponse { success: true })
+}
+
+async fn decode<M: Message + Default>(request: Request<Body>) -> Result<M> {
+    let (_, body) = request.into_parts();
+    let body = axum::body::to_bytes(body, usize::MAX)
+        .await
+        .map_err(|error| Error::Protocol(format!("cannot read rule request body: {error}")))?;
+    connect::decode_unary(&body)
+}
+
+fn proto(message: &impl Message) -> Result<Response<Body>> {
+    let body = message.encode_to_vec();
+    let mut response = Response::new(Body::from(body));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/proto"),
+    );
+    Ok(response)
+}
+
+fn rule_content(knowledge: &str) -> &str {
+    let trimmed = knowledge.trim();
+    let mut lines = trimmed.split_inclusive('\n');
+    if lines.next().is_none_or(|line| line.trim() != "---") {
+        return trimmed;
+    }
+    let mut offset = 0;
+    for line in trimmed.split_inclusive('\n') {
+        offset += line.len();
+        if offset > 4 && line.trim() == "---" {
+            return trimmed[offset..].trim();
+        }
+    }
+    trimmed
+}
+
+fn escape_xml(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn required_knowledge(knowledge: &str) -> Result<String> {
+    let knowledge = knowledge.trim();
+    if knowledge.is_empty() {
+        return Err(Error::Protocol("rule content is required".into()));
+    }
+    Ok(knowledge.to_owned())
+}
+
+struct RuleStore {
+    directory: PathBuf,
+}
+
+impl RuleStore {
+    fn open(directory: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&directory)?;
+        Ok(Self { directory })
+    }
+
+    fn add(&self, knowledge: String) -> Result<Rule> {
+        let id = Uuid::new_v4().to_string();
+        self.write(&id, &knowledge)?;
+        self.read(&id)
+    }
+
+    fn list(&self) -> Result<Vec<Rule>> {
+        let mut rules = fs::read_dir(&self.directory)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let path = entry.path();
+                (path.extension().and_then(|extension| extension.to_str()) == Some(RULE_EXTENSION))
+                    .then_some(path)
+            })
+            .map(|path| self.read_path(path))
+            .collect::<Result<Vec<_>>>()?;
+        rules.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+        Ok(rules)
+    }
+
+    fn update(&self, id: &str, knowledge: String) -> Result<()> {
+        let id = valid_id(id)?;
+        let path = self.path(&id);
+        if !path.exists() {
+            return Err(Error::RunNotFound(format!("global rule {id}")));
+        }
+        self.write(&id, &knowledge)
+    }
+
+    fn remove(&self, id: &str) -> Result<()> {
+        let id = valid_id(id)?;
+        let path = self.path(&id);
+        if !path.exists() {
+            return Err(Error::RunNotFound(format!("global rule {id}")));
+        }
+        fs::remove_file(path)?;
+        Ok(())
+    }
+
+    fn read(&self, id: &str) -> Result<Rule> {
+        self.read_path(self.path(id))
+    }
+
+    fn read_path(&self, path: PathBuf) -> Result<Rule> {
+        let knowledge = fs::read_to_string(&path)?;
+        let metadata = fs::metadata(&path)?;
+        let modified_at: DateTime<Utc> = metadata.modified()?.into();
+        let id = path
+            .file_stem()
+            .and_then(|id| id.to_str())
+            .ok_or_else(|| Error::Store("global rule path has no valid ID".into()))?
+            .to_owned();
+        Ok(Rule {
+            id,
+            knowledge,
+            created_at: modified_at.to_rfc3339(),
+        })
+    }
+
+    fn write(&self, id: &str, knowledge: &str) -> Result<()> {
+        let path = self.path(id);
+        let temporary = path.with_extension("tmp");
+        fs::write(&temporary, knowledge)?;
+        fs::rename(temporary, path)?;
+        Ok(())
+    }
+
+    fn path(&self, id: &str) -> PathBuf {
+        self.directory.join(format!("{id}.{RULE_EXTENSION}"))
+    }
+}
+
+fn valid_id(id: &str) -> Result<String> {
+    let id = id.trim();
+    Uuid::parse_str(id).map_err(|_| Error::Protocol("invalid global rule ID".into()))?;
+    Ok(id.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rule_response_uses_raw_protobuf_like_the_cursor_connect_handler() {
+        let response = proto(&KnowledgeBaseAddResponse {
+            success: true,
+            id: "rule-id".into(),
+        })
+        .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            KnowledgeBaseAddResponse::decode(body.as_ref()).unwrap(),
+            KnowledgeBaseAddResponse {
+                success: true,
+                id: "rule-id".into(),
+            }
+        );
+        assert_ne!(body.first(), Some(&0));
+    }
+
+    #[test]
+    fn rule_store_persists_the_full_global_rule_lifecycle() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = RuleStore::open(directory.path().to_path_buf()).unwrap();
+        let added = store.add("always write tests".into()).unwrap();
+        assert_eq!(store.list().unwrap(), vec![added.clone()]);
+
+        store
+            .update(&added.id, "always write regression tests".into())
+            .unwrap();
+        assert_eq!(
+            store.read(&added.id).unwrap().knowledge,
+            "always write regression tests"
+        );
+
+        store.remove(&added.id).unwrap();
+        assert!(store.list().unwrap().is_empty());
+    }
+}

--- a/server/src/harness/proxy.rs
+++ b/server/src/harness/proxy.rs
@@ -161,6 +161,10 @@ fn is_local_path(path: &str) -> bool {
             | "/aiserver.v1.DashboardService/GetUserProfile"
             | "/aiserver.v1.DashboardService/GetCurrentPeriodUsage"
             | "/aiserver.v1.DashboardService/GetUsageLimitStatusAndActiveGrants"
+            | "/aiserver.v1.AiService/KnowledgeBaseAdd"
+            | "/aiserver.v1.AiService/KnowledgeBaseList"
+            | "/aiserver.v1.AiService/KnowledgeBaseUpdate"
+            | "/aiserver.v1.AiService/KnowledgeBaseRemove"
             | "/aiserver.v1.AnalyticsService/BootstrapStatsig"
             | "/auth/full_stripe_profile"
     )
@@ -191,6 +195,10 @@ mod tests {
         assert!(is_local_path(
             "/aiserver.v1.AnalyticsService/BootstrapStatsig"
         ));
+        assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseAdd"));
+        assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseList"));
+        assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseUpdate"));
+        assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseRemove"));
         assert!(!is_local_path("/unrelated"));
         assert!(should_route_locally(
             "/aiserver.v1.AiService/StreamCpp",

--- a/server/src/harness/proxy.rs
+++ b/server/src/harness/proxy.rs
@@ -165,6 +165,7 @@ fn is_local_path(path: &str) -> bool {
             | "/aiserver.v1.AiService/KnowledgeBaseList"
             | "/aiserver.v1.AiService/KnowledgeBaseUpdate"
             | "/aiserver.v1.AiService/KnowledgeBaseRemove"
+            | "/aiserver.v1.AiService/FetchRelevantKnowledgeForConversation"
             | "/aiserver.v1.AnalyticsService/BootstrapStatsig"
             | "/auth/full_stripe_profile"
     )
@@ -199,6 +200,9 @@ mod tests {
         assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseList"));
         assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseUpdate"));
         assert!(is_local_path("/aiserver.v1.AiService/KnowledgeBaseRemove"));
+        assert!(is_local_path(
+            "/aiserver.v1.AiService/FetchRelevantKnowledgeForConversation"
+        ));
         assert!(!is_local_path("/unrelated"));
         assert!(should_route_locally(
             "/aiserver.v1.AiService/StreamCpp",


### PR DESCRIPTION
# Feature Pull Request

## User Story

- **As a:** Cursor BYOK user
- **I want to:** create and manage global rules from Cursor
- **So that:** my reusable instructions are applied to every locally routed model conversation.

## Acceptance Criteria

- [x] Cursor Knowledge Base add, list, update, and remove requests are handled locally.
- [x] Global rules persist at `~/.cursor-byok-v3/rules/global/`.
- [x] Every production prompt compiler reads the current global rules for each model request.
- [x] Global rules are appended to `PromptSpec.instructions`, which reaches OpenAI Chat, OpenAI Responses, and Anthropic system instructions.
- [x] Directly constructed test compilers do not read rules from the user’s local directory.
- [x] Rule frontmatter is excluded before a rule is appended to the model prompt.
- [x] Empty rule content is rejected.

## Key Changes

- Added `server/src/cursor/rules.rs` to manage persisted global rule files and Cursor-compatible protobuf handlers.
- Added local routing for the four Knowledge Base endpoints:
  - `KnowledgeBaseAdd`
  - `KnowledgeBaseList`
  - `KnowledgeBaseUpdate`
  - `KnowledgeBaseRemove`
- Added `~/.cursor-byok-v3/rules/global/` as the managed storage location for global rules.
- Configured the production `PromptCompiler` from `App` with the global rules directory.
- Appended active rules to `PromptSpec.instructions` in a `<shared_user_rules>` section.
- Escaped rule content for the XML-like prompt format and stripped optional Markdown frontmatter.
- Added unit tests for protobuf response encoding and the rule storage lifecycle.

## Demo

> N/A

## Testing

- [x] Self-reviewed
- [x] Unit / Integration Tests:
  - `cargo test rules::tests`
  - `cargo check`
- [x] Manual Test Steps:
  1. Start Cursor BYOK and configure the Cursor proxy.
  2. Create a global rule in Cursor.
  3. Confirm that the rule is listed and stored under `~/.cursor-byok-v3/rules/global/`.
  4. Start a new local/BYOK model conversation.
  5. Confirm the provider request contains the rule in its system instructions.
  6. Update or remove the rule and confirm subsequent model requests reflect the current rule set.

## Impact & Reviewer Notes

- **Database Migration:** No.
- **Environment Variables:** No.
- **Permissions / Access Control:** No new permissions.
- **Risk / Review Focus:** Review the protobuf contracts for the Knowledge Base endpoints and verify global rules are injected only by the production compiler, not direct test constructors.