### PR TITLE
fix: allow repeated automatic compaction

### DIFF
--- a/server/src/cursor/tools/result/gate.rs
+++ b/server/src/cursor/tools/result/gate.rs
@@ -1,4 +1,4 @@
-use crate::cursor::proto::agent::v1 as pb;
+use crate::{cursor::proto::agent::v1 as pb, model::truncate_edges};
 
 const KIB: usize = 1024;
 const SHELL_STREAM_LIMIT: usize = 16 * KIB;
@@ -41,43 +41,6 @@ fn gate_shell_result(result: &mut pb::ShellResult) {
         }
         _ => {}
     }
-}
-
-fn truncate_edges(tool_name: &str, content: &str, limit: usize) -> String {
-    if content.len() <= limit {
-        return content.to_string();
-    }
-    let original = content.len();
-    let mut shown = limit;
-    loop {
-        let notice = format!(
-            "\n\n[truncated: {tool_name} result exceeded {limit} bytes; omitted middle; showing {shown} of {original} bytes]\n\n"
-        );
-        let available = limit.saturating_sub(notice.len());
-        let head = utf8_prefix(content, available / 2);
-        let tail = utf8_suffix(content, available.saturating_sub(head.len()));
-        let next_shown = head.len().saturating_add(tail.len());
-        if next_shown == shown {
-            return format!("{head}{notice}{tail}");
-        }
-        shown = next_shown;
-    }
-}
-
-fn utf8_prefix(value: &str, limit: usize) -> &str {
-    let mut end = limit.min(value.len());
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    &value[..end]
-}
-
-fn utf8_suffix(value: &str, limit: usize) -> &str {
-    let mut start = value.len().saturating_sub(limit);
-    while start < value.len() && !value.is_char_boundary(start) {
-        start += 1;
-    }
-    &value[start..]
 }
 
 #[cfg(test)]

--- a/server/src/model/mod.rs
+++ b/server/src/model/mod.rs
@@ -11,6 +11,7 @@ mod run;
 mod runtime_tag;
 mod token_count;
 mod tool;
+mod truncation;
 mod usage;
 
 pub use configuration::*;
@@ -26,4 +27,5 @@ pub use run::*;
 pub use runtime_tag::*;
 pub(crate) use token_count::*;
 pub use tool::*;
+pub(crate) use truncation::*;
 pub use usage::*;

--- a/server/src/model/projection.rs
+++ b/server/src/model/projection.rs
@@ -5,9 +5,12 @@ use serde::{Deserialize, Serialize};
 use crate::{Error, Result};
 
 use super::{
-    CanonicalMessage, ContentPart, MessageContent, ProviderReplayState, Role, ToolCallContent,
-    ToolResultContent,
+    truncate_edges, CanonicalMessage, ContentPart, MessageContent, ProviderReplayState, Role,
+    ToolCallContent, ToolResultContent,
 };
+
+const KIB: usize = 1024;
+const TOOL_RESULT_CONTENT_LIMIT: usize = 64 * KIB;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ProjectedContent {
@@ -106,7 +109,10 @@ fn project_tool_round(
                     result.call_id
                 )));
             }
-            results.push((messages[cursor].message_id.clone(), result.clone()));
+            results.push((
+                messages[cursor].message_id.clone(),
+                project_tool_result(result),
+            ));
             cursor += 1;
         }
     }
@@ -159,11 +165,79 @@ fn project_message(message: &CanonicalMessage) -> ProjectedMessage {
             replay_state: replay_state.clone(),
             calls: tool_calls.clone(),
         },
-        MessageContent::ToolResult(result) => ProjectedContent::ToolResult(result.clone()),
+        MessageContent::ToolResult(result) => {
+            ProjectedContent::ToolResult(project_tool_result(result))
+        }
     };
     ProjectedMessage {
         message_id: message.message_id.clone(),
         role: message.role.clone(),
         content,
+    }
+}
+
+fn project_tool_result(result: &ToolResultContent) -> ToolResultContent {
+    let mut projected = result.clone();
+    let label = format!("{} tool", result.name);
+    projected.content = truncate_edges(&label, &projected.content, TOOL_RESULT_CONTENT_LIMIT);
+    for part in &mut projected.provider_parts {
+        if let ContentPart::Text { text } = part {
+            *text = truncate_edges(&label, text, TOOL_RESULT_CONTENT_LIMIT);
+        }
+    }
+    projected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Origin;
+
+    #[test]
+    fn oversized_tool_results_are_bounded_only_in_provider_projection() {
+        let original = format!("HEAD{}TAIL", "x".repeat(1024 * KIB));
+        let message = CanonicalMessage {
+            message_id: "result".into(),
+            role: Role::Tool,
+            origin: Origin::Tool,
+            content: MessageContent::ToolResult(ToolResultContent {
+                call_id: "call".into(),
+                name: "Read".into(),
+                content: original.clone(),
+                is_error: false,
+                image: None,
+                provider_parts: vec![ContentPart::Text {
+                    text: original.clone(),
+                }],
+            }),
+            runtime_event_id: None,
+        };
+
+        let projected = project_messages(std::slice::from_ref(&message)).unwrap();
+        let ProjectedContent::ToolResult(result) = &projected[0].content else {
+            panic!("expected projected tool result");
+        };
+
+        assert!(result.content.len() <= TOOL_RESULT_CONTENT_LIMIT);
+        assert!(result.content.starts_with("HEAD"));
+        assert!(result.content.ends_with("TAIL"));
+        assert!(result
+            .content
+            .contains("Re-run the tool with narrower scope"));
+        let [ContentPart::Text { text }] = result.provider_parts.as_slice() else {
+            panic!("expected projected text part");
+        };
+        assert!(text.len() <= TOOL_RESULT_CONTENT_LIMIT);
+        assert!(text.starts_with("HEAD"));
+        assert!(text.ends_with("TAIL"));
+
+        let MessageContent::ToolResult(stored) = &message.content else {
+            panic!("expected canonical tool result");
+        };
+        assert_eq!(stored.content, original);
+        assert_eq!(
+            stored.provider_parts[0],
+            ContentPart::Text { text: original }
+        );
     }
 }

--- a/server/src/model/truncation.rs
+++ b/server/src/model/truncation.rs
@@ -1,0 +1,36 @@
+pub(crate) fn truncate_edges(label: &str, content: &str, limit: usize) -> String {
+    if content.len() <= limit {
+        return content.to_string();
+    }
+    let original = content.len();
+    let mut shown = limit;
+    loop {
+        let notice = format!(
+            "\n\n[truncated: {label} result exceeded {limit} bytes; omitted middle; showing {shown} of {original} bytes. Re-run the tool with narrower scope to inspect omitted content.]\n\n"
+        );
+        let available = limit.saturating_sub(notice.len());
+        let head = utf8_prefix(content, available / 2);
+        let tail = utf8_suffix(content, available.saturating_sub(head.len()));
+        let next_shown = head.len().saturating_add(tail.len());
+        if next_shown == shown {
+            return format!("{head}{notice}{tail}");
+        }
+        shown = next_shown;
+    }
+}
+
+fn utf8_prefix(value: &str, limit: usize) -> &str {
+    let mut end = limit.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn utf8_suffix(value: &str, limit: usize) -> &str {
+    let mut start = value.len().saturating_sub(limit);
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
+    }
+    &value[start..]
+}

--- a/server/src/run/engine.rs
+++ b/server/src/run/engine.rs
@@ -166,7 +166,7 @@ impl RunEngine {
             };
         }
 
-        let mut auto_compacted = prepared.action == RunAction::Compact;
+        let mut last_auto_compaction_revision = None;
         'model: loop {
             if cancellation.is_cancelled() {
                 return (RunOutcome::Cancelled, usage);
@@ -175,7 +175,9 @@ impl RunEngine {
                 Ok(messages) => messages,
                 Err(error) => return (RunOutcome::Failed(error.into()), usage),
             };
-            let context_anchor = if !auto_compacted && prepared.action == RunAction::Start {
+            let auto_compaction_allowed =
+                auto_compaction_allowed(&prepared.action, revision, last_auto_compaction_revision);
+            let context_anchor = if auto_compaction_allowed {
                 match self
                     .store
                     .latest_llm_call_usage_anchor(
@@ -190,14 +192,14 @@ impl RunEngine {
             } else {
                 None
             };
-            if !auto_compacted && should_auto_compact(prepared, &messages, context_anchor) {
-                auto_compacted = true;
+            if auto_compaction_allowed && should_auto_compact(prepared, &messages, context_anchor) {
                 match self
                     .auto_compact(prepared, revision, &messages, client, cancellation)
                     .await
                 {
                     Ok((next_revision, compaction_usage)) => {
                         revision = next_revision;
+                        last_auto_compaction_revision = Some(revision);
                         if let Some(compaction_usage) = compaction_usage {
                             accumulate_usage(&mut usage, compaction_usage);
                         }
@@ -533,7 +535,7 @@ impl RunEngine {
                 (fallback_summary(&compactable), failure.usage)
             }
         };
-        let event_id = format!("summary:auto:{}", prepared.run_id);
+        let event_id = format!("summary:auto:{}:{provider_call_index}", prepared.run_id);
         let summary_message = CanonicalMessage {
             message_id: format!("runtime:{event_id}"),
             role: Role::User,
@@ -646,6 +648,14 @@ fn should_auto_compact(
         })
         .unwrap_or_else(|| estimate_context_tokens(&prepared.prompt, messages));
     estimated_input > context_window.saturating_sub(COMPACTION_RESERVE_TOKENS)
+}
+
+fn auto_compaction_allowed(
+    action: &RunAction,
+    revision: crate::model::RevisionId,
+    last_auto_compaction_revision: Option<crate::model::RevisionId>,
+) -> bool {
+    matches!(action, RunAction::Start) && last_auto_compaction_revision != Some(revision)
 }
 
 fn estimate_context_tokens(
@@ -801,8 +811,8 @@ fn failure_message(failure: &RunFailure) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        auto_compaction_partition, estimate_context_tokens, hydrate_tool_images,
-        should_auto_compact, ContextUsageAnchor,
+        auto_compaction_allowed, auto_compaction_partition, estimate_context_tokens,
+        hydrate_tool_images, should_auto_compact, ContextUsageAnchor,
     };
     use crate::{
         model::{
@@ -913,6 +923,29 @@ mod tests {
         };
 
         assert!(should_auto_compact(&prepared, &messages, Some(anchor)));
+    }
+
+    #[test]
+    fn automatic_compaction_can_run_again_after_the_revision_advances() {
+        let first = RevisionId(1);
+        let after_more_tool_results = RevisionId(2);
+
+        assert!(auto_compaction_allowed(&RunAction::Start, first, None));
+        assert!(!auto_compaction_allowed(
+            &RunAction::Start,
+            first,
+            Some(first)
+        ));
+        assert!(auto_compaction_allowed(
+            &RunAction::Start,
+            after_more_tool_results,
+            Some(first)
+        ));
+        assert!(!auto_compaction_allowed(
+            &RunAction::Compact,
+            after_more_tool_results,
+            None
+        ));
     }
 
     #[test]

--- a/server/src/run/engine.rs
+++ b/server/src/run/engine.rs
@@ -6,8 +6,8 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     client::{ClientEvent, ClientPort, CommitBarrier, CommitCause, StateCommitted},
     model::{
-        CanonicalMessage, MessageContent, Origin, PreparedRun, Role, RunAction, ToolRoundAssistant,
-        ToolRoundId, Usage,
+        CanonicalMessage, MessageContent, Origin, PreparedRun, ProjectedMessage, Role, RunAction,
+        ToolRoundAssistant, ToolRoundId, Usage,
     },
     provider::Provider,
     store::{RunStatus, Store},
@@ -175,6 +175,10 @@ impl RunEngine {
                 Ok(messages) => messages,
                 Err(error) => return (RunOutcome::Failed(error.into()), usage),
             };
+            let projected_history = match crate::model::project_messages(&messages) {
+                Ok(history) => history,
+                Err(error) => return (RunOutcome::Failed(error.into()), usage),
+            };
             let auto_compaction_allowed =
                 auto_compaction_allowed(&prepared.action, revision, last_auto_compaction_revision);
             let context_anchor = if auto_compaction_allowed {
@@ -192,7 +196,9 @@ impl RunEngine {
             } else {
                 None
             };
-            if auto_compaction_allowed && should_auto_compact(prepared, &messages, context_anchor) {
+            if auto_compaction_allowed
+                && should_auto_compact(prepared, &messages, &projected_history, context_anchor)
+            {
                 match self
                     .auto_compact(prepared, revision, &messages, client, cancellation)
                     .await
@@ -217,10 +223,7 @@ impl RunEngine {
                 revision_id = revision.0,
                 "starting model call"
             );
-            let mut history = match crate::model::project_messages(&messages) {
-                Ok(history) => history,
-                Err(error) => return (RunOutcome::Failed(error.into()), usage),
-            };
+            let mut history = projected_history;
             if let Err(error) = hydrate_tool_images(&self.store, &mut history).await {
                 return (RunOutcome::Failed(error.into()), usage);
             }
@@ -622,7 +625,8 @@ impl ContextUsageAnchor {
 
 fn should_auto_compact(
     prepared: &PreparedRun,
-    messages: &[CanonicalMessage],
+    canonical_messages: &[CanonicalMessage],
+    projected_history: &[ProjectedMessage],
     anchor: Option<ContextUsageAnchor>,
 ) -> bool {
     if prepared.action != RunAction::Start {
@@ -632,21 +636,21 @@ fn should_auto_compact(
         return false;
     };
     if context_window <= COMPACTION_RESERVE_TOKENS
-        || messages.len() <= prepared.initial_messages.len()
+        || canonical_messages.len() <= prepared.initial_messages.len()
     {
         return false;
     }
     let estimated_input = anchor
         .filter(|anchor| {
-            anchor.message_count <= messages.len()
+            anchor.message_count <= projected_history.len()
                 && anchor.tool_count == prepared.prompt.tools.len()
         })
         .map(|anchor| {
-            anchor
-                .input_tokens
-                .saturating_add(estimate_message_tokens(&messages[anchor.message_count..]))
+            anchor.input_tokens.saturating_add(estimate_message_tokens(
+                &projected_history[anchor.message_count..],
+            ))
         })
-        .unwrap_or_else(|| estimate_context_tokens(&prepared.prompt, messages));
+        .unwrap_or_else(|| estimate_context_tokens(&prepared.prompt, projected_history));
     estimated_input > context_window.saturating_sub(COMPACTION_RESERVE_TOKENS)
 }
 
@@ -660,13 +664,13 @@ fn auto_compaction_allowed(
 
 fn estimate_context_tokens(
     prompt: &crate::model::PromptSpec,
-    messages: &[CanonicalMessage],
+    messages: &[ProjectedMessage],
 ) -> u64 {
     let serialized = serde_json::to_string(&(prompt, messages)).unwrap_or_default();
     estimate_serialized_tokens(&serialized)
 }
 
-fn estimate_message_tokens(messages: &[CanonicalMessage]) -> u64 {
+fn estimate_message_tokens(messages: &[ProjectedMessage]) -> u64 {
     let serialized = serde_json::to_string(messages).unwrap_or_default();
     estimate_serialized_tokens(&serialized)
 }
@@ -812,13 +816,13 @@ fn failure_message(failure: &RunFailure) -> String {
 mod tests {
     use super::{
         auto_compaction_allowed, auto_compaction_partition, estimate_context_tokens,
-        hydrate_tool_images, should_auto_compact, ContextUsageAnchor,
+        estimate_serialized_tokens, hydrate_tool_images, should_auto_compact, ContextUsageAnchor,
     };
     use crate::{
         model::{
-            CanonicalMessage, ContentPart, ConversationId, ModelSpec, Origin, PreparedRun,
-            ProjectedContent, ProjectedMessage, PromptSpec, RevisionId, Role, RunAction, RunId,
-            RunKind, ToolImageReference, ToolResultContent,
+            project_messages, CanonicalMessage, ContentPart, ConversationId, MessageContent,
+            ModelSpec, Origin, PreparedRun, ProjectedContent, ProjectedMessage, PromptSpec,
+            RevisionId, Role, RunAction, RunId, RunKind, ToolImageReference, ToolResultContent,
         },
         store::Store,
     };
@@ -842,6 +846,8 @@ mod tests {
             Origin::User,
             "x".repeat(100_000),
         )];
+        let short = project_messages(&short).unwrap();
+        let long = project_messages(&long).unwrap();
 
         assert!(estimate_context_tokens(&prompt, &long) > 25_000);
         assert!(estimate_context_tokens(&prompt, &long) > estimate_context_tokens(&prompt, &short));
@@ -880,12 +886,15 @@ mod tests {
             message_count: 1,
             tool_count: 0,
         };
+        let projected = project_messages(&messages).unwrap();
 
-        assert_eq!(
-            estimate_context_tokens(&prepared.prompt, &messages),
-            190_813
-        );
-        assert!(!should_auto_compact(&prepared, &messages, Some(anchor)));
+        assert!(estimate_context_tokens(&prepared.prompt, &projected) > 180_000);
+        assert!(!should_auto_compact(
+            &prepared,
+            &messages,
+            &projected,
+            Some(anchor)
+        ));
     }
 
     #[test]
@@ -921,8 +930,65 @@ mod tests {
             message_count: 1,
             tool_count: 0,
         };
+        let projected = project_messages(&messages).unwrap();
 
-        assert!(should_auto_compact(&prepared, &messages, Some(anchor)));
+        assert!(should_auto_compact(
+            &prepared,
+            &messages,
+            &projected,
+            Some(anchor)
+        ));
+    }
+
+    #[test]
+    fn stored_full_tool_result_does_not_cause_early_compaction_after_projection() {
+        let current_runtime = CanonicalMessage::text(
+            "runtime:current",
+            Role::User,
+            Origin::Runtime,
+            "current request",
+        );
+        let messages = vec![
+            CanonicalMessage::text("history", Role::User, Origin::User, "old context"),
+            CanonicalMessage {
+                message_id: "large-result".into(),
+                role: Role::Tool,
+                origin: Origin::Tool,
+                content: MessageContent::ToolResult(ToolResultContent {
+                    call_id: "call".into(),
+                    name: "Glob".into(),
+                    content: "x".repeat(4 * 1024 * 1024),
+                    is_error: false,
+                    image: None,
+                    provider_parts: Vec::new(),
+                }),
+                runtime_event_id: None,
+            },
+            current_runtime.clone(),
+        ];
+        let prepared = PreparedRun {
+            run_id: RunId::new("run"),
+            cursor_request_id: None,
+            conversation_id: ConversationId::new("conversation"),
+            kind: RunKind::Root,
+            model: ModelSpec {
+                context_window_tokens: Some(800_000),
+                ..ModelSpec::new("model")
+            },
+            prompt: PromptSpec {
+                instructions: "system".into(),
+                tools: Vec::new(),
+            },
+            initial_messages: vec![current_runtime],
+            action: RunAction::Start,
+            base_revision_id: RevisionId(1),
+        };
+        let projected = project_messages(&messages).unwrap();
+        let stored = serde_json::to_string(&(&prepared.prompt, &messages)).unwrap();
+
+        assert!(estimate_serialized_tokens(&stored) > 790_000);
+        assert!(estimate_context_tokens(&prepared.prompt, &projected) < 790_000);
+        assert!(!should_auto_compact(&prepared, &messages, &projected, None));
     }
 
     #[test]

--- a/server/tests/tool_loop.rs
+++ b/server/tests/tool_loop.rs
@@ -20,7 +20,10 @@ use cursor_server::{
         },
     },
     cursor::{CursorCommand, CursorSessionRegistry},
-    model::{MessageContent, ToolCall},
+    model::{
+        MessageContent, ModelConfigInput, ModelType, ProjectedContent, ToolCall,
+        OPENAI_CHAT_ENDPOINT,
+    },
     provider::{FinishReason, ModelEvent},
 };
 use prost::Message;
@@ -989,7 +992,251 @@ async fn provider_tool_use_waits_for_client_result_then_calls_provider_again() {
     assert_eq!(tool_calls[0].call_id, "call-1");
 }
 
+#[tokio::test]
+async fn one_run_can_auto_compact_again_after_more_tool_output() {
+    let (directory, store) = fixtures::temp_store().await;
+    let model = store
+        .create_model(&ModelConfigInput {
+            sort_order: 0,
+            display_name: "Repeated compaction".into(),
+            model_type: ModelType::OpenAi,
+            base_url: "https://example.com/v1/chat/completions".into(),
+            use_full_url: true,
+            api_key: "test-key".into(),
+            tooltip_data: "Repeated compaction".into(),
+            model_id: "repeated-compaction-model".into(),
+            reasoning_effort: None,
+            openai_endpoint: OPENAI_CHAT_ENDPOINT.into(),
+            openai_extra_params_enabled: false,
+            openai_extra_params: json!({}),
+            custom_headers_enabled: false,
+            custom_headers: json!({}),
+            anthropic_extra_params_enabled: false,
+            anthropic_extra_params: json!({}),
+            context_window_tokens: Some(200_000),
+            max_completion_tokens: None,
+            anthropic_max_tokens: None,
+            anthropic_thinking_effort: None,
+            thinking_budget_tokens: None,
+        })
+        .await
+        .unwrap();
+    let provider = fake_provider::FakeProvider::default();
+    provider.push(tool_call_response("call-1"));
+    provider.push(text_events("first summary"));
+    provider.push(tool_call_response("call-2"));
+    provider.push(text_events("second summary"));
+    provider.push(text_events("done"));
+    let assets = PromptAssets::load(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("prompt/cursor")
+            .as_path(),
+    )
+    .unwrap();
+    let registry = CursorSessionRegistry::new(
+        store.clone(),
+        Arc::new(provider.clone()),
+        PromptCompiler::new(assets),
+        Default::default(),
+    );
+    let handle = registry
+        .get_or_create("repeated-compaction-request")
+        .await
+        .unwrap();
+    let mut output = handle.subscribe();
+    handle
+        .command(CursorCommand::Append {
+            seqno: 0,
+            message: Box::new(client_run_for_model(
+                "repeated-compaction-conversation",
+                "repeated-compaction-request",
+                &model.model_hash,
+                Some("200k"),
+            )),
+        })
+        .await
+        .unwrap();
+    let mut seqno = 1;
+    let oversized = format!("HEAD{}TAIL", "x".repeat(4 * 1024 * 1024));
+    loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(5), output.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let (flags, payload) = connect::decode_frames(&frame).unwrap().pop().unwrap();
+        if flags & connect::END_STREAM_FLAG != 0 {
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(&payload).unwrap(),
+                json!({})
+            );
+            break;
+        }
+        let server = pb::AgentServerMessage::decode(payload).unwrap();
+        match server.message {
+            Some(pb::agent_server_message::Message::KvServerMessage(kv)) => {
+                handle
+                    .command(CursorCommand::Append {
+                        seqno,
+                        message: Box::new(kv_ack(kv.id)),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+            }
+            Some(pb::agent_server_message::Message::ExecServerMessage(exec)) => {
+                let exec_id = exec.id;
+                handle
+                    .command(CursorCommand::Append {
+                        seqno,
+                        message: Box::new(pb::AgentClientMessage {
+                            message: Some(pb::agent_client_message::Message::ExecClientMessage(
+                                pb::ExecClientMessage {
+                                    id: exec_id,
+                                    message: Some(pb::exec_client_message::Message::ReadResult(
+                                        pb::ReadResult {
+                                            result: Some(pb::read_result::Result::Success(
+                                                pb::ReadSuccess {
+                                                    path: "/tmp/large.txt".into(),
+                                                    total_lines: 1,
+                                                    file_size: oversized.len() as i64,
+                                                    output: Some(
+                                                        pb::read_success::Output::Content(
+                                                            oversized.clone(),
+                                                        ),
+                                                    ),
+                                                    ..Default::default()
+                                                },
+                                            )),
+                                        },
+                                    )),
+                                    ..Default::default()
+                                },
+                            )),
+                        }),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+                handle
+                    .command(CursorCommand::Append {
+                        seqno,
+                        message: Box::new(pb::AgentClientMessage {
+                            message: Some(
+                                pb::agent_client_message::Message::ExecClientControlMessage(
+                                    pb::ExecClientControlMessage {
+                                        message: Some(
+                                            pb::exec_client_control_message::Message::StreamClose(
+                                                pb::ExecClientStreamClose { id: exec_id },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        }),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+            }
+            _ => {}
+        }
+    }
+
+    let requests = provider.requests();
+    let shapes = requests
+        .iter()
+        .map(|request| {
+            (
+                request.model.context_window_tokens,
+                request.prompt.tools.len(),
+                request.history.len(),
+                request
+                    .history
+                    .iter()
+                    .filter_map(|message| match &message.content {
+                        ProjectedContent::ToolResult(result) => Some(result.content.len()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(requests.len(), 5, "provider requests: {shapes:?}");
+    assert!(!requests[0].prompt.tools.is_empty());
+    assert!(requests[1].prompt.tools.is_empty());
+    assert!(!requests[2].prompt.tools.is_empty());
+    assert!(requests[3].prompt.tools.is_empty());
+    assert!(!requests[4].prompt.tools.is_empty());
+    for request in [&requests[1], &requests[3]] {
+        let result = request
+            .history
+            .iter()
+            .find_map(|message| match &message.content {
+                ProjectedContent::ToolResult(result) => Some(result),
+                _ => None,
+            })
+            .expect("compaction request must contain a projected tool result");
+        assert!(result.content.len() <= 64 * 1024);
+        assert!(result.content.contains("omitted middle"));
+    }
+    let database = sqlx::SqlitePool::connect(&format!(
+        "sqlite://{}",
+        directory.path().join("test.db").display()
+    ))
+    .await
+    .unwrap();
+    let full_result_lengths =
+        sqlx::query_scalar::<_, i64>("SELECT length(result_content) FROM tool_round_calls")
+            .fetch_all(&database)
+            .await
+            .unwrap();
+    assert_eq!(full_result_lengths.len(), 2);
+    assert!(full_result_lengths
+        .iter()
+        .all(|length| *length > 4 * 1024 * 1024));
+}
+
+fn tool_call_response(call_id: &str) -> Vec<ModelEvent> {
+    vec![
+        ModelEvent::Start {
+            model_call_id: format!("model-{call_id}"),
+        },
+        ModelEvent::ToolCallStart {
+            index: 0,
+            call_id: call_id.into(),
+            name: "Read".into(),
+        },
+        ModelEvent::ToolCallArgumentsDelta {
+            index: 0,
+            delta: "{\"path\":\"/tmp/large.txt\"}".into(),
+        },
+        ModelEvent::ToolCallEnd { index: 0 },
+        ModelEvent::Done(FinishReason::ToolUse),
+    ]
+}
+
+fn text_events(text: &str) -> Vec<ModelEvent> {
+    vec![
+        ModelEvent::Start {
+            model_call_id: format!("model-{text}"),
+        },
+        ModelEvent::TextStart,
+        ModelEvent::TextDelta(text.into()),
+        ModelEvent::TextEnd,
+        ModelEvent::Done(FinishReason::Stop),
+    ]
+}
+
 fn client_run() -> pb::AgentClientMessage {
+    client_run_for_model("tool-conversation", "tool-request", "test-model", None)
+}
+
+fn client_run_for_model(
+    conversation_id: &str,
+    run_id: &str,
+    model_id: &str,
+    context: Option<&str>,
+) -> pb::AgentClientMessage {
     let user = pb::UserMessage {
         text: "read it".into(),
         message_id: "user".into(),
@@ -1008,10 +1255,17 @@ fn client_run() -> pb::AgentClientMessage {
                     )),
                     ..Default::default()
                 }),
-                conversation_id: Some("tool-conversation".into()),
-                run_id: Some("tool-request".into()),
+                conversation_id: Some(conversation_id.into()),
+                run_id: Some(run_id.into()),
                 requested_model: Some(pb::RequestedModel {
-                    model_id: "test-model".into(),
+                    model_id: model_id.into(),
+                    parameters: context
+                        .into_iter()
+                        .map(|value| pb::requested_model::ModelParameterValue {
+                            id: "context".into(),
+                            value: value.into(),
+                        })
+                        .collect(),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/server/tests/tool_loop.rs
+++ b/server/tests/tool_loop.rs
@@ -1013,7 +1013,7 @@ async fn one_run_can_auto_compact_again_after_more_tool_output() {
             custom_headers: json!({}),
             anthropic_extra_params_enabled: false,
             anthropic_extra_params: json!({}),
-            context_window_tokens: Some(200_000),
+            context_window_tokens: Some(40_000),
             max_completion_tokens: None,
             anthropic_max_tokens: None,
             anthropic_thinking_effort: None,
@@ -1051,7 +1051,7 @@ async fn one_run_can_auto_compact_again_after_more_tool_output() {
                 "repeated-compaction-conversation",
                 "repeated-compaction-request",
                 &model.model_hash,
-                Some("200k"),
+                Some("40k"),
             )),
         })
         .await


### PR DESCRIPTION
## Summary

- allow automatic compaction to run again after a new revision adds more context
- generate a unique runtime event ID for every automatic compaction
- cap model-projected tool-result text at 64 KiB while preserving the complete result in local storage
- reuse one UTF-8-safe head/tail truncation helper for provider projection and shell output

## Motivation

A long Agent run can compact successfully and then receive another multi-megabyte tool result. The previous one-shot guard prevented a second compaction, so the next provider request could fail with `context_too_large`. Reusing the same automatic-summary event ID also caused the store to reject a second summary with different content.

## Testing

- `cargo test -p cursor-server --lib automatic_compaction_can_run_again_after_the_revision_advances`
- `cargo test -p cursor-server --lib oversized_tool_results_are_bounded_only_in_provider_projection`
- `cargo test -p cursor-server --test tool_loop one_run_can_auto_compact_again_after_more_tool_output`

The integration regression test produces two consecutive 4 MiB Read results in one Agent run and verifies the sequence normal call → compaction → normal call → compaction → final call. Each provider projection is limited to 64 KiB, while both complete results remain stored in SQLite.