### PR TITLE
fix: omit empty tools array from provider requests

### DIFF
--- a/server/src/provider/anthropic.rs
+++ b/server/src/provider/anthropic.rs
@@ -54,11 +54,13 @@ impl Provider for AnthropicProvider {
                 .unwrap_or(DEFAULT_MAX_OUTPUT_TOKENS);
             let mut body = json!({
                 "model": request.model.model_id, "system": request.prompt.instructions, "messages": messages,
-                "max_tokens": max_tokens, "stream": true,
-                "tools": request.prompt.tools.iter().map(|tool| json!({
-                    "name": tool.name, "description": tool.description, "input_schema": tool.parameters
-                })).collect::<Vec<_>>()
+                "max_tokens": max_tokens, "stream": true
             });
+            if !request.prompt.tools.is_empty() {
+                body["tools"] = json!(request.prompt.tools.iter().map(|tool| json!({
+                    "name": tool.name, "description": tool.description, "input_schema": tool.parameters
+                })).collect::<Vec<_>>());
+            }
             apply_model(&mut body, &request.model)?;
             merge_extra_params(&mut body, &request.model.extra_params)?;
             if let Some(recorder) = &recorder {

--- a/server/src/provider/openai_chat.rs
+++ b/server/src/provider/openai_chat.rs
@@ -65,12 +65,14 @@ impl Provider for OpenAiChatProvider {
             let mut body = json!({
                 "model": request.model.model_id,
                 "messages": messages,
-                "tools": request.prompt.tools.iter().map(|tool| json!({"type":"function","function":{
-                    "name": tool.name, "description": tool.description, "parameters": tool.parameters
-                }})).collect::<Vec<_>>(),
                 "stream": true,
                 "stream_options": {"include_usage": true}
             });
+            if !request.prompt.tools.is_empty() {
+                body["tools"] = json!(request.prompt.tools.iter().map(|tool| json!({"type":"function","function":{
+                    "name": tool.name, "description": tool.description, "parameters": tool.parameters
+                }})).collect::<Vec<_>>());
+            }
             apply_model(&mut body, &request.model, config.max_output_tokens)?;
             merge_extra_params(&mut body, &request.model.extra_params)?;
             apply_openai_prompt_cache_key(&mut body, &request.model.model_id)?;

--- a/server/src/provider/openai_responses.rs
+++ b/server/src/provider/openai_responses.rs
@@ -69,12 +69,14 @@ impl Provider for OpenAiResponsesProvider {
             let mut body = json!({
                 "model": request.model.model_id, "input": input, "stream": true,
                 "instructions": request.prompt.instructions,
-                "include": ["reasoning.encrypted_content"],
-                "tools": request.prompt.tools.iter().map(|tool| json!({
+                "include": ["reasoning.encrypted_content"]
+            });
+            if !request.prompt.tools.is_empty() {
+                body["tools"] = json!(request.prompt.tools.iter().map(|tool| json!({
                     "type":"function", "name":tool.name, "description":tool.description,
                     "parameters":tool.parameters, "strict":false
-                })).collect::<Vec<_>>()
-            });
+                })).collect::<Vec<_>>());
+            }
             apply_model(&mut body, &request.model, config.max_output_tokens)?;
             merge_extra_params(&mut body, &request.model.extra_params)?;
             apply_openai_prompt_cache_key(&mut body, &request.model.model_id)?;


### PR DESCRIPTION
## Summary
- vLLM and some OpenAI-compatible APIs reject requests containing an empty `tools: []` array with `400 Bad Request`
- The model connectivity test sends no tools, causing the test to fail against vLLM servers
- Conditionally include the `tools` field in request bodies only when tools are present, across all three providers (OpenAI Chat, OpenAI Responses, Anthropic)

## Error reproduced
```
连通性测试失败：provider error: OpenAI Chat 400 Bad Request: {"error":{"message":"`tools` must not be an empty array. Either provide at least one tool or omit the field entirely. (parameter=tools)","type":"BadRequestError","param":"tools","code":400}}
```

## Test plan
- [x] `cargo check` passes
- [x] All existing connectivity tests pass (`cargo test -p cursor-server connectivity`)
- [ ] Manual verification: configure a vLLM endpoint and run the model connectivity test