### PR TITLE
fix: accept reasoning field in OpenAI Chat streams（ When using Ollama Cloud）

### DIFF
--- a/server/src/provider/openai_chat.rs
+++ b/server/src/provider/openai_chat.rs
@@ -132,7 +132,7 @@ impl Provider for OpenAiChatProvider {
                 }
                 let Some(choice) = value.get("choices").and_then(Value::as_array).and_then(|values| values.first()) else { continue; };
                 let delta = choice.get("delta").unwrap_or(&Value::Null);
-                if let Some(reasoning_delta) = delta.get("reasoning_content").and_then(Value::as_str).filter(|text| !text.is_empty()) {
+                if let Some(reasoning_delta) = delta.get("reasoning_content").or_else(|| delta.get("reasoning")).and_then(Value::as_str).filter(|text| !text.is_empty()) {
                     if !thinking_open { thinking_open = true; yield ModelEvent::ThinkingStart; }
                     reasoning.push_str(reasoning_delta);
                     yield ModelEvent::ThinkingDelta(reasoning_delta.into());


### PR DESCRIPTION
## Summary

OpenAI-compatible providers may stream reasoning as either
`delta.reasoning_content` or `delta.reasoning`.

Ollama Cloud uses `delta.reasoning`, so its thinking output is currently ignored.

This adds `reasoning` as a fallback while preserving the existing
`reasoning_content` behavior.

Tested against:

- `https://ollama.com/v1/chat/completions`
- model: `glm-5.2`
- `reasoning_effort: high`
- streaming response uses `delta.reasoning`
- no `reasoning_content` observed