### PR TITLE
fix(tools): reject empty old_string in EditNotebook

### DIFF
--- a/server/src/cursor/tools/edit.rs
+++ b/server/src/cursor/tools/edit.rs
@@ -183,6 +183,9 @@ fn edit_notebook(call: &ToolCall, before: &str) -> std::result::Result<String, S
             .unwrap_or_default();
         let old =
             normalize_newlines(&string(call, "old_string").map_err(|error| error.to_string())?);
+        if old.is_empty() {
+            return Err("old_string must not be empty".into());
+        }
         let occurrences = source.match_indices(&old).count();
         let edited = match occurrences {
             0 => return Err("old_string was not found in the notebook cell".into()),
@@ -240,4 +243,50 @@ fn normalized(value: &str) -> String {
         .filter(|character| character.is_ascii_alphanumeric())
         .flat_map(char::to_lowercase)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::edit_notebook;
+    use crate::model::ToolCall;
+
+    fn notebook_call(old_string: &str) -> ToolCall {
+        ToolCall {
+            index: 0,
+            call_id: "call".into(),
+            model_call_id: "model".into(),
+            name: "EditNotebook".into(),
+            arguments_text: String::new(),
+            arguments: json!({
+                "target_notebook": "/notebook.ipynb",
+                "cell_idx": 0,
+                "old_string": old_string,
+                "new_string": "replacement",
+            }),
+        }
+    }
+
+    fn single_cell_notebook() -> String {
+        json!({
+            "cells": [{"cell_type": "code", "source": ["print('hi')\n"]}],
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn edit_notebook_rejects_empty_old_string() {
+        // StrReplace rejects an empty old_string; EditNotebook must do the same
+        // instead of prepending new_string (empty cell) or reporting a
+        // misleading "not unique" error (non-empty cell).
+        let error = edit_notebook(&notebook_call(""), &single_cell_notebook()).unwrap_err();
+        assert_eq!(error, "old_string must not be empty");
+    }
+
+    #[test]
+    fn edit_notebook_replaces_a_unique_old_string() {
+        let edited = edit_notebook(&notebook_call("hi"), &single_cell_notebook()).unwrap();
+        assert!(edited.contains("print('replacement')"));
+    }
 }


### PR DESCRIPTION
## What

`StrReplace` rejects an empty `old_string`, but the `EditNotebook` cell-edit path did not.

## Why

In `edit_notebook` (`server/src/cursor/tools/edit.rs`), an empty `old_string` is passed straight to `str::match_indices`, which matches at **every** byte boundary. So an empty `old_string`:

- on a **non-empty** cell fails with the misleading `old_string is not unique in the notebook cell; found N occurrences` (N = char count + 1), and
- on an **empty** cell silently prepends `new_string` (1 match).

`replace_string` (StrReplace) already guards against this with `if old.is_empty() { return Err("old_string must not be empty") }`. This adds the same guard to `edit_notebook` so both edit tools behave consistently.

## Test

Added two unit tests in `edit.rs`:
- `edit_notebook_rejects_empty_old_string` — asserts the clean `old_string must not be empty` error (fails before this change with `... found 13 occurrences`).
- `edit_notebook_replaces_a_unique_old_string` — happy path still works.

```
cargo test -p cursor-server --lib cursor::tools::edit   # 2 passed
cargo fmt --all -- --check                              # clean
```