### PR TITLE
fix: handle tool calls with empty arguments

### DIFF
--- a/server/src/cursor/conversation/output.rs
+++ b/server/src/cursor/conversation/output.rs
@@ -343,7 +343,14 @@ impl ConversationOutput {
                         let call = calls.get_mut(&index).ok_or_else(|| {
                             Error::Protocol(format!("unknown completed tool index: {index}"))
                         })?;
-                        call.arguments = serde_json::from_str(&call.arguments_text)?;
+                        // A tool call with no arguments streams no argument text.
+                        // Treat empty text as an empty object, matching the model
+                        // cycle, instead of failing the run on `from_str("")`.
+                        call.arguments = if call.arguments_text.trim().is_empty() {
+                            serde_json::json!({})
+                        } else {
+                            serde_json::from_str(&call.arguments_text)?
+                        };
                     }
                     RunEvent::Usage(usage) => {
                         if !self.context.compacting {

--- a/server/src/store/tool_rounds.rs
+++ b/server/src/store/tool_rounds.rs
@@ -101,7 +101,14 @@ impl Store {
             .bind(&call.call_id)
             .bind(&call.model_call_id)
             .bind(&call.name)
-            .bind(&call.arguments_text)
+            // A no-argument tool call streams no argument text; persist it as an
+            // empty object so the `arguments_json` column always holds valid JSON
+            // and can be re-parsed on load.
+            .bind(if call.arguments_text.trim().is_empty() {
+                "{}"
+            } else {
+                call.arguments_text.as_str()
+            })
             .execute(&mut *tx)
             .await?;
         }

--- a/server/tests/interrupt.rs
+++ b/server/tests/interrupt.rs
@@ -507,6 +507,68 @@ async fn runtime_user_message_action_interrupts_and_continues_with_new_message()
 }
 
 #[tokio::test]
+async fn tool_call_with_empty_arguments_does_not_fail_the_run() {
+    // A tool call that carries no arguments streams no argument text. Parsing it
+    // as JSON must yield an empty object (as the model cycle already does), not
+    // fail the run with `EOF while parsing a value`.
+    let (_directory, store) = fixtures::temp_store().await;
+    let provider = fake_provider::FakeProvider::default();
+    provider.push(tool_response("call-1", "UpdateCurrentStep", ""));
+    provider.push(text_response("done after empty-argument tool"));
+    let assets = PromptAssets::load(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("prompt/cursor")
+            .as_path(),
+    )
+    .unwrap();
+    let registry = TransportRegistry::new(
+        store,
+        Arc::new(provider.clone()),
+        PromptCompiler::new(assets),
+    );
+    let handle = registry.get_or_create("empty-args-request").await.unwrap();
+    let mut output = handle.subscribe();
+    handle
+        .command(TransportCommand::Append {
+            seqno: 0,
+            message: Box::new(client_run_for(
+                "empty-args-request",
+                "empty-args-conversation",
+            )),
+        })
+        .await
+        .unwrap();
+
+    let mut append_seqno = 1;
+    let mut saw_done = false;
+    loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(5), output.recv())
+            .await
+            .unwrap()
+            .expect("RunSSE closed before successful EndStream");
+        let (flags, payload) = connect::decode_frames(&frame).unwrap().pop().unwrap();
+        if flags & connect::END_STREAM_FLAG != 0 {
+            assert_eq!(
+                payload.as_ref(),
+                b"{}",
+                "run failed: {}",
+                String::from_utf8_lossy(&payload)
+            );
+            break;
+        }
+        let server = pb::AgentServerMessage::decode(payload).unwrap();
+        if let Some(pb::agent_server_message::Message::InteractionUpdate(update)) = server.message {
+            if let Some(pb::interaction_update::Message::TextDelta(delta)) = update.message {
+                saw_done |= delta.text.contains("done after empty-argument tool");
+            }
+        }
+        acknowledge_kv(&handle, &mut append_seqno, &frame).await;
+    }
+    assert!(saw_done);
+    assert_eq!(provider.requests().len(), 2);
+}
+
+#[tokio::test]
 async fn injected_user_context_restarts_only_the_active_model_cycle() {
     let (_directory, store) = fixtures::temp_store().await;
     let provider = fake_provider::FakeProvider::default();


### PR DESCRIPTION
## What

A tool call with no arguments streams no argument text, so `arguments_text` is empty. Parsing `""` as JSON fails with `EOF while parsing a value at line 1 column 0`, which **aborts the whole run**.

`model_cycle` already guards this (`if arguments_text.trim().is_empty() { json!({}) }`), but two other consumers of the same text did not:

1. **`ConversationOutput`** re-derives `arguments` from the streamed text on `RunEvent::ToolCallEnd` (`conversation/output.rs`) — `serde_json::from_str(&call.arguments_text)?`.
2. **Persistence**: `create_tool_round` stored the empty text verbatim into the `arguments_json` column, so when the round is loaded back (`commit_tool_result` and the round loader in `store/tool_rounds.rs`) it fails on `from_str("")` — even the parsed `{}` from the model cycle is discarded, because only the raw text is persisted.

Either path turns a legitimate no-argument tool call into a failed turn.

## Fix

- Treat empty argument text as an empty object in the output projection (mirrors the model cycle).
- Persist `{}` instead of empty text so the `arguments_json` column always holds valid JSON and round-trips cleanly.

## Test

Added `interrupt::tool_call_with_empty_arguments_does_not_fail_the_run`: a tool call with empty arguments now completes and the run reaches a successful EndStream. Before this change it fails with `EOF while parsing a value`.

```
cargo test -p cursor-server --test interrupt   # 15 passed (new test fails on main)
cargo fmt --all -- --check                     # clean
```