### PR TITLE
fix(tests): acknowledge conversation Blob writes in the local rules test

### DIFF
--- a/server/tests/local_rules_context.rs
+++ b/server/tests/local_rules_context.rs
@@ -16,6 +16,7 @@ use cursor_server::{
     model::{ContentPart, ProjectedContent},
     provider::{FinishReason, ModelEvent},
 };
+use prost::Message;
 
 #[tokio::test]
 async fn local_markdown_rules_land_in_the_request_context_message() {
@@ -58,17 +59,29 @@ async fn local_markdown_rules_land_in_the_request_context_message() {
         .await
         .unwrap();
 
+    let mut append_seqno = 1;
     loop {
         let frame = tokio::time::timeout(std::time::Duration::from_secs(5), output.recv())
             .await
             .expect("run finishes within timeout")
             .expect("output stays open until EndStream");
-        let ended = connect::decode_frames(&frame)
-            .unwrap()
-            .iter()
-            .any(|(flags, _)| flags & connect::END_STREAM_FLAG != 0);
-        if ended {
+        let (flags, payload) = connect::decode_frames(&frame).unwrap().pop().unwrap();
+        if flags & connect::END_STREAM_FLAG != 0 {
             break;
+        }
+        // The Run waits for the client to confirm every conversation Blob write,
+        // so the stream only advances once each KvServerMessage is acknowledged.
+        if let Some(pb::agent_server_message::Message::KvServerMessage(kv)) =
+            pb::AgentServerMessage::decode(payload).unwrap().message
+        {
+            handle
+                .command(TransportCommand::Append {
+                    seqno: append_seqno,
+                    message: Box::new(set_blob_result(kv.id)),
+                })
+                .await
+                .unwrap();
+            append_seqno += 1;
         }
     }
 
@@ -100,6 +113,19 @@ async fn local_markdown_rules_land_in_the_request_context_message() {
     );
 
     registry.shutdown().await;
+}
+
+fn set_blob_result(id: u32) -> pb::AgentClientMessage {
+    pb::AgentClientMessage {
+        message: Some(pb::agent_client_message::Message::KvClientMessage(
+            pb::KvClientMessage {
+                id,
+                message: Some(pb::kv_client_message::Message::SetBlobResult(
+                    pb::SetBlobResult { error: None },
+                )),
+            },
+        )),
+    }
 }
 
 fn user_run() -> pb::AgentClientMessage {


### PR DESCRIPTION
## Problem

`cargo test --workspace` fails on `main`:

```
     Running tests\local_rules_context.rs
test local_markdown_rules_land_in_the_request_context_message ... FAILED

thread '...' panicked at server\tests\local_rules_context.rs:64:14:
run finishes within timeout: Elapsed(())
```

It is the only failing target in the workspace, and it fails on every platform — it is not flaky and not environment-specific.

## Cause

The Run publishes the conversation checkpoint by asking the client to write Blobs, and it does not continue until every `KvServerMessage` is answered with a `SetBlobResult`.

The test drained the output stream without replying, so the Run stalled after the very first frame. I confirmed this by instrumenting the loop: exactly one frame arrives, then nothing for 60s, and `provider.requests()` stays empty — the provider is never invoked, so **none of the assertions the test exists for were ever reached**.

## Fix

Answer the Blob writes the way every other transport test already does (`error_lifecycle.rs`, `conversation_delivery.rs`, `interrupt.rs` all follow this pattern).

With the acknowledgement in place the Run reaches `EndStream` in ~0.3s and the original assertions run and pass, so `merge_local_rules` is now genuinely covered: exactly one `request-context:` message is projected and it carries `<user_rule>Always answer in haiku.</user_rule>`.

**No production code changes** — this is a test-only fix.

## Verification

```
# before
$ cargo test -p cursor-server --test local_rules_context
test result: FAILED. 0 passed; 1 failed  (after a 5s timeout)

# after
$ cargo test -p cursor-server --test local_rules_context
test result: ok. 1 passed; 0 failed; finished in 0.28s

$ cargo fmt --all -- --check      # clean for this file
$ cargo clippy --workspace --all-targets   # clean for this file
```
