### PR TITLE
fix(provider): keep OpenAI Chat tool calls that finish with reason "stop"

### DIFF
--- a/server/src/provider/openai_chat.rs
+++ b/server/src/provider/openai_chat.rs
@@ -368,7 +368,9 @@ fn map_finish(value: &str, has_tools: bool) -> FinishReason {
     match value {
         "tool_calls" | "function_call" => FinishReason::ToolUse,
         "length" => FinishReason::Length,
-        "stop" | "content_filter" => FinishReason::Stop,
+        // Observed tool calls outrank whatever the provider labelled the stop:
+        // OpenAI-compatible servers routinely report "stop" while streaming tool
+        // calls, and the run rejects a finish reason that contradicts them.
         _ if has_tools => FinishReason::ToolUse,
         _ => FinishReason::Stop,
     }
@@ -432,5 +434,32 @@ pub(crate) fn openai_usage(value: &Value) -> Usage {
         reasoning_tokens: value
             .pointer("/completion_tokens_details/reasoning_tokens")
             .and_then(Value::as_u64),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observed_tool_calls_outrank_a_stop_finish_reason() {
+        assert_eq!(map_finish("stop", true), FinishReason::ToolUse);
+        assert_eq!(map_finish("content_filter", true), FinishReason::ToolUse);
+        assert_eq!(map_finish("", true), FinishReason::ToolUse);
+    }
+
+    #[test]
+    fn finish_reason_mapping_without_tool_calls_is_unchanged() {
+        assert_eq!(map_finish("stop", false), FinishReason::Stop);
+        assert_eq!(map_finish("content_filter", false), FinishReason::Stop);
+        assert_eq!(map_finish("", false), FinishReason::Stop);
+        assert_eq!(map_finish("tool_calls", false), FinishReason::ToolUse);
+        assert_eq!(map_finish("function_call", false), FinishReason::ToolUse);
+    }
+
+    #[test]
+    fn a_truncated_response_stays_truncated_even_with_tool_calls() {
+        assert_eq!(map_finish("length", true), FinishReason::Length);
+        assert_eq!(map_finish("length", false), FinishReason::Length);
     }
 }


### PR DESCRIPTION
## Problem

`map_finish` matched `"stop" | "content_filter"` **before** the `has_tools` fallback, so the fallback only ever applied to finish reasons the adapter did not recognise:

```rust
fn map_finish(value: &str, has_tools: bool) -> FinishReason {
    match value {
        "tool_calls" | "function_call" => FinishReason::ToolUse,
        "length" => FinishReason::Length,
        "stop" | "content_filter" => FinishReason::Stop,   // <- wins over has_tools
        _ if has_tools => FinishReason::ToolUse,
        _ => FinishReason::Stop,
    }
}
```

When an OpenAI-compatible server streams tool calls and then reports `finish_reason: "stop"`, the adapter yields `Done(Stop)` even though `ToolCallStart` / `ToolCallEnd` were already emitted. `run/model_cycle.rs` rejects that combination:

```rust
let has_tool_calls = !calls.is_empty();
if matches!(finish_reason, FinishReason::ToolUse) != has_tool_calls {
    return Err(failure(RunFailure::Protocol(
        "finish reason and tool calls disagree".into()), ...));
}
```

So the whole turn fails with a protocol error and the tool never runs.

Reproducing SSE:

```
data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Read","arguments":""}}]},"finish_reason":null}]}
data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":\"a.txt\"}"}}]},"finish_reason":null}]}
data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
data: [DONE]
```

Servers that report `"stop"` alongside `tool_calls` are common in BYOK setups (llama.cpp, Ollama's OpenAI shim, several proxies), which makes those models unusable for anything agentic.

## Fix

Move the `has_tools` arm ahead of `"stop" | "content_filter"` so an observed tool call outranks the label the provider attached to the stop.

This matches the two sibling adapters and this adapter's own `[DONE]` fallback:

| site | precedence |
|---|---|
| `anthropic.rs:242` | `Length`, then `_ if saw_tool => ToolUse`, then the reported reason |
| `openai_responses.rs:243` | `if saw_tool { ToolUse } else { Stop }` |
| `openai_chat.rs:214` (`[DONE]` path) | `if tools.is_empty() { Stop } else { ToolUse }` |
| `openai_chat.rs::map_finish` | **the only place that trusted the label over observed state** |

`"length"` still wins, so a truncated response is still reported as truncated, and behaviour with no tool calls is byte-for-byte unchanged.

## Verification

```
# before (with the "stop" arm restored)
$ cargo test -p cursor-server --lib provider::openai_chat
observed_tool_calls_outrank_a_stop_finish_reason ... FAILED
  assertion `left == right` failed
    left: Stop
   right: ToolUse
test result: FAILED. 2 passed; 1 failed

# after
$ cargo test -p cursor-server --lib provider::openai_chat
test result: ok. 3 passed; 0 failed

$ cargo fmt --all -- --check                # clean for this file
$ cargo clippy --workspace --all-targets    # clean for this file
```
