### PR TITLE
fix(tools): keep result truncation inside its byte budget and terminating

### DIFF
--- a/server/src/cursor/tools/tool_call_result/gate.rs
+++ b/server/src/cursor/tools/tool_call_result/gate.rs
@@ -258,7 +258,9 @@ fn gate_grep_content(content: &mut pb::GrepContentResult, budget: &mut GrepBudge
                 truncated = true;
                 break;
             }
-            budget.content_bytes -= next_match.content.len();
+            budget.content_bytes = budget
+                .content_bytes
+                .saturating_sub(next_match.content.len());
             budget.matches -= 1;
             next.matches.push(next_match);
         }
@@ -630,15 +632,25 @@ fn truncate_text(tool_name: &str, content: &str, limit: usize) -> String {
     }
     let original = content.len();
     let mut shown = limit;
+    let mut previous = None;
     loop {
         let notice = format!(
             "\n\n[truncated: {tool_name} result exceeded {limit} bytes; showing {shown} of {original} bytes]"
         );
-        let available = limit.saturating_sub(notice.len());
-        let kept = utf8_prefix(content, available);
-        if kept.len() == shown {
+        if notice.len() >= limit {
+            // The notice alone would blow the budget; keep a plain prefix so the
+            // result never costs more than `limit` bytes.
+            return utf8_prefix(content, limit).to_string();
+        }
+        let kept = utf8_prefix(content, limit - notice.len());
+        // `notice.len()` grows with the digit count of `shown`, so `kept.len()`
+        // can alternate between two values across a power-of-ten boundary
+        // instead of reaching a fixed point. Settle on the first repeat; the
+        // reported count is then off by one at most and the result still fits.
+        if kept.len() == shown || previous == Some(kept.len()) {
             return format!("{}{notice}", kept.trim_end_matches('\n'));
         }
+        previous = Some(shown);
         shown = kept.len();
     }
 }
@@ -684,4 +696,84 @@ fn utf8_suffix(value: &str, limit: usize) -> &str {
         start += 1;
     }
     &value[start..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grep_tool(matches: Vec<String>) -> pb::tool_call::Tool {
+        pb::tool_call::Tool::GrepToolCall(pb::GrepToolCall {
+            args: None,
+            result: Some(pb::GrepResult {
+                result: Some(pb::grep_result::Result::Success(pb::GrepSuccess {
+                    active_editor_result: Some(pb::GrepUnionResult {
+                        result: Some(pb::grep_union_result::Result::Content(
+                            pb::GrepContentResult {
+                                matches: vec![pb::GrepFileMatch {
+                                    file: "src/lib.rs".into(),
+                                    matches: matches
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(index, content)| pb::GrepContentMatch {
+                                            line_number: index as i32 + 1,
+                                            content,
+                                            ..Default::default()
+                                        })
+                                        .collect(),
+                                }],
+                                ..Default::default()
+                            },
+                        )),
+                    }),
+                    ..Default::default()
+                })),
+            }),
+        })
+    }
+
+    #[test]
+    fn truncate_text_never_exceeds_its_limit() {
+        let content = "b".repeat(200);
+        for limit in 1..=250 {
+            let output = truncate_text("Grep", &content, limit);
+            assert!(
+                output.len() <= limit,
+                "limit {limit} produced {} bytes",
+                output.len()
+            );
+        }
+    }
+
+    #[test]
+    fn truncate_text_terminates_when_the_notice_length_oscillates() {
+        // `limit` values where the notice grows and shrinks with the digit count
+        // of the reported byte count, so the fixed point is never reached.
+        assert!(truncate_text("Grep", &"b".repeat(200), 78).len() <= 78);
+        assert!(truncate_text("Grep", &"b".repeat(200), 170).len() <= 170);
+        assert!(truncate_text("MCP text", &"b".repeat(500), 82).len() <= 82);
+    }
+
+    #[test]
+    fn grep_content_gate_survives_a_nearly_exhausted_byte_budget() {
+        // 16 matches leave 16 bytes of the 32 KiB content budget, which is less
+        // than the truncation notice for the 17th match.
+        let mut matches = vec!["a".repeat(2047); 16];
+        matches.push("b".repeat(100));
+        let mut tool = grep_tool(matches);
+        let mut content = String::new();
+        tool_completion("Grep", &mut tool, &mut content);
+    }
+
+    #[test]
+    fn grep_content_gate_terminates_on_an_oscillating_remaining_budget() {
+        // The same path, tuned so the remaining budget lands on a `limit` where
+        // the truncation notice length oscillates.
+        let mut matches = vec!["a".repeat(2043); 15];
+        matches.push("a".repeat(2045));
+        matches.push("b".repeat(200));
+        let mut tool = grep_tool(matches);
+        let mut content = String::new();
+        tool_completion("Grep", &mut tool, &mut content);
+    }
 }


### PR DESCRIPTION
## Problem

`truncate_text` looks for a fixed point where the kept prefix length equals the byte count printed in its own truncation notice:

```rust
let mut shown = limit;
loop {
    let notice = format!("...exceeded {limit} bytes; showing {shown} of {original} bytes]");
    let available = limit.saturating_sub(notice.len());
    let kept = utf8_prefix(content, available);
    if kept.len() == shown { return format!("{}{notice}", kept.trim_end_matches('\n')); }
    shown = kept.len();
}
```

Two things go wrong when the limit is small, and both are reachable because two call sites pass a **remaining** budget rather than a constant:

* `gate_grep_content` -> `truncate_text("Grep", .., budget.content_bytes)` (`gate.rs:253`)
* `gate_mcp` -> `truncate_text("MCP text", .., remaining_text)` (`gate.rs:408`)

### 1. The loop can spin forever

`notice.len()` grows with the decimal digit count of `shown`, so `kept.len()` alternates between two values across a power-of-ten boundary and never equals `shown`:

```
limit 78, content 200B, tool "Grep":
  shown=78 -> notice=69 -> available=9  -> kept=9
  shown=9  -> notice=68 -> available=10 -> kept=10
  shown=10 -> notice=69 -> available=9  -> kept=9   ... forever
```

The conversation task then spins at 100% CPU and the turn never completes. With `"Grep"` this happens at `limit` 78 and 170; with `"MCP text"` at 82 and 174. Sibling `truncate_middle` in `model/tool_result_replay.rs:174` already carries the guard that is missing here.

### 2. The result can exceed its own limit

When the notice itself does not fit, `available` saturates to 0 and the function returns the ~68 byte notice alone — i.e. *more* than `limit`. `gate_grep_content` then evaluates:

```rust
budget.content_bytes -= next_match.content.len();   // 16usize - 68
```

which panics with `attempt to subtract with overflow` in debug/test builds and wraps in release, silently disabling the 32 KiB content cap for the rest of the result. This is the only unguarded subtraction in the file — lines 409, 586, 590, 593, 658 and 682 all use `saturating_sub`.

### Reachability

Both are one ordinary Grep result away. 16 matches of ~2 KiB leave a two-digit remainder of the 32 KiB budget, and the 17th match then hits the small-limit path. Both new `gate` tests drive the real `tool_completion("Grep", ..)` entry point with exactly that shape.

Every constant-limit call site is unaffected: I checked all of them, their notices always fit and their limits do not oscillate.

## Fix

* Return a plain prefix when the notice cannot fit, so the result is always at most `limit` bytes.
* Stop as soon as the kept length repeats a previous value. (The step function is non-increasing in the digit count, so only fixed points and 2-cycles exist; one remembered value is enough.) In that rare oscillating case the reported byte count is off by one at most.
* `budget.content_bytes` now uses `saturating_sub`, matching the rest of the file.

## Verification

```
# before, against the unfixed function
$ cargo test -p cursor-server --lib gate::tests::truncate_text_never_exceeds_its_limit
FAILED: limit 1 produced 67 bytes

$ cargo test -p cursor-server --lib gate::tests::grep_content_gate_survives
FAILED: panicked at gate.rs:261: attempt to subtract with overflow

$ timeout 45 cargo test -p cursor-server --lib gate::tests::truncate_text_terminates
exit 124 — never returns

$ timeout 60 cargo test -p cursor-server --lib gate::tests::grep_content_gate_terminates
exit 124 — never returns

# after
$ cargo test -p cursor-server --lib tools::tool_call_result::gate
test result: ok. 4 passed; 0 failed

$ cargo fmt --all -- --check                # clean for this file
$ cargo clippy --workspace --all-targets    # clean for this file
```
