### PR TITLE
fix(provider): stop retrying provider responses that cannot succeed

### DIFF
--- a/server/src/provider/retry.rs
+++ b/server/src/provider/retry.rs
@@ -59,7 +59,7 @@ where
             "{label} {status}: {}",
             String::from_utf8_lossy(&bytes)
         ));
-        if attempt == policy.retries {
+        if attempt == policy.retries || !is_retryable(status) {
             return Err(error);
         }
         tracing::warn!(
@@ -81,4 +81,107 @@ where
         }
     }
     unreachable!("the retry loop returns on the final attempt")
+}
+
+/// Reports whether repeating the request could plausibly change the answer.
+/// A rejected request - wrong key, unknown model, malformed or oversized body -
+/// fails identically every time, so retrying it only delays the error the user
+/// needs to see.
+fn is_retryable(status: reqwest::StatusCode) -> bool {
+    use reqwest::StatusCode;
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_EARLY | StatusCode::TOO_MANY_REQUESTS
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::*;
+
+    /// Serves one fixed status line and counts the requests it received.
+    async fn stub(status_line: &'static str) -> (String, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = hits.clone();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                counter.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buffer = [0_u8; 2048];
+                    let _ = socket.read(&mut buffer).await;
+                    let response = format!(
+                        "HTTP/1.1 {status_line}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        (format!("http://{address}/"), hits)
+    }
+
+    async fn attempts(status_line: &'static str, retries: u32) -> usize {
+        let (url, hits) = stub(status_line).await;
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let body = serde_json::json!({"model": "test"});
+        let result = send_with_retry(
+            "test",
+            || client.post(&url).json(&body),
+            RetryPolicy {
+                retries,
+                delay: Duration::from_millis(10),
+            },
+            &CancellationToken::new(),
+            None,
+            serde_json::Value::Null,
+            &body,
+        )
+        .await;
+        assert!(result.is_err(), "{status_line} must surface as an error");
+        hits.load(Ordering::SeqCst)
+    }
+
+    #[tokio::test]
+    async fn a_rejected_request_is_not_retried() {
+        for status_line in [
+            "400 Bad Request",
+            "401 Unauthorized",
+            "403 Forbidden",
+            "404 Not Found",
+            "413 Payload Too Large",
+            "422 Unprocessable Entity",
+        ] {
+            assert_eq!(
+                attempts(status_line, 5).await,
+                1,
+                "{status_line} must be reported immediately"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_transient_failure_still_uses_the_whole_policy() {
+        for status_line in [
+            "408 Request Timeout",
+            "429 Too Many Requests",
+            "500 Internal Server Error",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+        ] {
+            assert_eq!(
+                attempts(status_line, 2).await,
+                3,
+                "{status_line} must be retried"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`send_with_retry` treats every non-2xx response as retryable — the only test is `response.status().is_success()`:

```rust
if response.status().is_success() {
    return Ok(Attempt::Response(response));
}
...
if attempt == policy.retries {
    return Err(error);
}
```

With the built-in policy (`BUILTIN_PROVIDER_RETRIES = 5`, `RetryPolicy::default().delay = 5s`) a request the provider has **rejected** is sent 6 times with 5 seconds of sleeping between attempts.

The everyday cases are exactly the ones that cannot improve on a repeat:

| user mistake | status | today |
|---|---|---|
| mistyped API key | 401 | 6 requests, ~25s before "401" appears |
| model id the endpoint does not serve | 404 | same |
| body the endpoint rejects | 400 / 422 | same |

Every attempt also opens a new `llm_calls` row through `recorder.retry()` (`{call_id}:retry-N`), so one wrong key writes 6 rows, 5 of them errors.

During first-time BYOK setup — the moment these statuses are most likely — the app looks hung for 25 seconds and then reports the error it already had at t=0.

## Fix

Add `is_retryable` and stop early for statuses a repeat cannot resolve.

5xx, 408, 425 and 429 keep the full policy, so genuine provider overload and rate limiting still back off exactly as before. Backoff shape, delay and the user-configurable `retry_count` are unchanged — this only decides *which* failures are worth repeating.

## Verification

The new tests drive the real `send_with_retry` against a local TCP stub that serves one fixed status and counts requests (no new dependencies — `tokio`'s `net` feature is already enabled).

```
# before (with `if attempt == policy.retries` restored)
$ cargo test -p cursor-server --lib provider::retry
a_rejected_request_is_not_retried ... FAILED
  assertion `left == right` failed: 400 Bad Request must be reported immediately
    left: 6
   right: 1
a_transient_failure_still_uses_the_whole_policy ... ok
test result: FAILED. 1 passed; 1 failed

# after
$ cargo test -p cursor-server --lib provider::retry
test result: ok. 2 passed; 0 failed

$ cargo fmt --all -- --check                # clean for this file
$ cargo clippy --workspace --all-targets    # clean for this file
```

Note that `a_transient_failure_still_uses_the_whole_policy` passes **both** before and after — 408/429/500/502/503 each still get all `retries + 1` attempts, so the retry path itself is provably unchanged.
