### PR TITLE
chore: restore a green `make check` on main

### DIFF
--- a/server/src/plugin/data.rs
+++ b/server/src/plugin/data.rs
@@ -209,6 +209,10 @@ fn set_directory_permissions(path: &Path) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
     }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
     Ok(())
 }
 
@@ -217,6 +221,10 @@ fn set_file_permissions(path: &Path) -> Result<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
     }
     Ok(())
 }

--- a/server/src/provider/openai_responses.rs
+++ b/server/src/provider/openai_responses.rs
@@ -154,9 +154,8 @@ impl Provider for OpenAiResponsesProvider {
                         if !thinking_open { thinking_open = true; yield ModelEvent::ThinkingStart; }
                         if let Some(delta) = value.get("delta").and_then(Value::as_str) { yield ModelEvent::ThinkingDelta(delta.into()); }
                     }
-                    "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
-                        if thinking_open { thinking_open = false; yield ModelEvent::ThinkingEnd; }
-                    }
+                    "response.reasoning_summary_text.done" | "response.reasoning_text.done"
+                        if thinking_open => { thinking_open = false; yield ModelEvent::ThinkingEnd; }
                     "response.output_item.added" => {
                         let item = value.get("item").unwrap_or(&Value::Null);
                         if item.get("type").and_then(Value::as_str) == Some("function_call") {

--- a/server/src/store/models.rs
+++ b/server/src/store/models.rs
@@ -323,6 +323,18 @@ fn model_from_row(row: sqlx::sqlite::SqliteRow) -> Result<ModelConfig> {
     })
 }
 
+fn optional_u64(row: &sqlx::sqlite::SqliteRow, column: &str) -> Result<Option<u64>> {
+    row.try_get::<Option<i64>, _>(column)?
+        .map(|value| {
+            u64::try_from(value).map_err(|_| Error::Config(format!("{column} cannot be negative")))
+        })
+        .transpose()
+}
+
+fn to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value).map_err(|_| Error::Config("token value is too large".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,16 +398,4 @@ mod tests {
         assert_eq!(cleared.model_hash, created.model_hash);
         assert_eq!(cleared.group_name, None);
     }
-}
-
-fn optional_u64(row: &sqlx::sqlite::SqliteRow, column: &str) -> Result<Option<u64>> {
-    row.try_get::<Option<i64>, _>(column)?
-        .map(|value| {
-            u64::try_from(value).map_err(|_| Error::Config(format!("{column} cannot be negative")))
-        })
-        .transpose()
-}
-
-fn to_i64(value: u64) -> Result<i64> {
-    i64::try_from(value).map_err(|_| Error::Config("token value is too large".into()))
 }

--- a/server/tests/knowledge_rules.rs
+++ b/server/tests/knowledge_rules.rs
@@ -125,7 +125,10 @@ async fn offline_crud_round_trip_persists_markdown() {
     .unwrap();
     let added: AddResponse = decode(response).await;
     assert!(added.success);
-    assert!(added.id.starts_with("local-"), "offline add uses a local id");
+    assert!(
+        added.id.starts_with("local-"),
+        "offline add uses a local id"
+    );
     let markdown = rules_root.join(format!("{}.md", added.id));
     assert_eq!(
         std::fs::read_to_string(&markdown).unwrap(),


### PR DESCRIPTION
## Problem

`make check` does not pass on a clean checkout of `main`. Before touching
anything, `ee2592c` gives one `cargo fmt` diff and four `cargo clippy` errors:

```
$ cargo fmt --all -- --check
Diff in server/tests/knowledge_rules.rs:125

$ cargo clippy --workspace --all-targets -- -D warnings
error: unused variable: `path`               server/src/plugin/data.rs:206:30
error: unused variable: `path`               server/src/plugin/data.rs:215:25
error: this `if` can be collapsed into the outer `match`
                                             server/src/provider/openai_responses.rs:158:25
error: items after a test module              server/src/store/models.rs:327:1
error: could not compile `cursor-server` (lib) due to 3 previous errors
error: could not compile `cursor-server` (lib test) due to 4 previous errors
```

All five are pre-existing and none is a behaviour change. Since the two
`data.rs` ones are `#[cfg]`-dependent they only appear off Unix, which is
probably why they went unnoticed.

## Fix

Four mechanical repairs, one per diagnostic:

**`server/tests/knowledge_rules.rs:125`** — ran `cargo fmt --all` and took
its output verbatim (the long `assert!` gets split across lines). No other
file moved.

**`server/src/plugin/data.rs:206,215`** — `path` is only read inside
`#[cfg(unix)]`, so on every other target the parameter is unused. Added a
`#[cfg(not(unix))] { let _ = path; }` arm, which is the idiom this same
file already uses at line 189:

```rust
#[cfg(not(windows))]
{
    let _ = error;
    false
}
```

To be explicit about what this does **not** do: these two helpers remain
no-ops on Windows, exactly as before. I only silenced the binding, I did
not change the permission behaviour. If you would rather also restrict
ACLs on Windows that is a real feature and a separate PR — happy to open
one if you want it.

**`server/src/provider/openai_responses.rs:158`** — `collapsible_match`.
I applied clippy's own suggestion (lift `thinking_open` into a match
guard). This is safe here because the `match kind { .. }` ends in
`_ => {}` (line 255) and every arm between is a distinct string literal,
so when the guard is false the arm falls through to a no-op — which is
precisely what the inner `if` did.

**`server/src/store/models.rs:327`** — `items_after_test_module`. Moved
`optional_u64` and `to_i64` above `mod tests`. Bodies untouched; this is
a pure relocation.

I deliberately did not reach for `#[allow(..)]` anywhere.

## Verification

```
$ cargo fmt --all -- --check
(clean, exit 0)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.78s
(clean, exit 0)
```

`cargo test --workspace --all-targets` still has one failure, and it is
**not** from this PR — `local_rules_context::local_markdown_rules_land_in_the_request_context_message`
times out identically before and after this change. That one is what
#390 fixes; with #390 and this PR, the three Rust gates in `make check`
are all green.

I did not touch the two `npm run check` steps.

## Note

There is no PR-triggered CI in this repo (`release.yml` is tag-only),
which is most likely how this drifted in the first place. I have a small
follow-up workflow that runs exactly these `Makefile` gates — happy to
open it separately if that is useful, or to leave it alone.
