### PR TITLE
ci: run the Makefile check gates on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # The workspace includes apps/desktop/src-tauri, so even `cargo check`
+      # needs the same system libraries the release workflow installs.
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo test --workspace --all-targets
+        run: cargo test --workspace --all-targets


### PR DESCRIPTION
## Motivation

This one is a proposal rather than a fix, so please treat it as a
suggestion — I am happy to adjust the shape or just close it if you
would rather set CI up differently.

`release.yml` is the only workflow, and it triggers on `v*` tags only.
Nothing checks a commit before it reaches `main`. The observable
consequence is that `main` does not currently pass its own `make check`:

```
$ git checkout main && git rev-parse --short HEAD
ee2592c

$ cargo fmt --all -- --check
Diff in server/tests/knowledge_rules.rs:125

$ cargo clippy --workspace --all-targets -- -D warnings
error: unused variable: `path`                server/src/plugin/data.rs:206:30
error: unused variable: `path`                server/src/plugin/data.rs:215:25
error: this `if` can be collapsed into the outer `match`
                                              server/src/provider/openai_responses.rs:158:25
error: items after a test module               server/src/store/models.rs:327:1

$ cargo test --workspace --all-targets
test local_markdown_rules_land_in_the_request_context_message ... FAILED
```

None of those are dramatic on their own, and that is rather the point —
they are exactly the class of thing a PR gate catches for free and that
otherwise accumulates quietly.

## What this adds

One job, running the three Rust gates exactly as the `Makefile` already
spells them — no new lint set, no new configuration, nothing you are not
already running locally:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

on `pull_request` and on `push` to `main`.

Everything else copies `release.yml` so the two stay consistent rather
than drifting apart:

- `ubuntu-22.04` and the same four apt packages. These are needed even
  for `cargo check`, because `apps/desktop/src-tauri` is a workspace
  member and pulls in webkit2gtk.
- `dtolnay/rust-toolchain@stable` (there is no `rust-toolchain.toml`
  pinning anything, so I followed release.yml's `stable`; happy to pin
  if you would prefer that).
- `Swatinem/rust-cache@v2` with the same `. -> target` workspace key.
- `permissions: contents: read`, and a `concurrency` group so pushes to
  a PR cancel the superseded run.

`protoc` is vendored via `protoc-bin-vendored` in `server/build.rs`, so
there is nothing extra to install for the proto codegen.

## What I deliberately left out

`make check` also runs `npm --prefix apps/desktop run check` and
`npm --prefix apps/docs run check`. I left both out to keep this small
and because I have not verified them, not because I think they do not
belong. Say the word and I will add a second job for them.

## Please read this before merging

**On today's `main` this workflow will be red**, which is precisely the
condition it is reporting. It goes green once two things land:

- #395 fixes the `fmt` diff and the four `clippy` errors.
- #390 fixes the `local_rules_context` test timeout.

So the natural order is #395 and #390 first, then this. If you would
rather it not gate anything until the tree is clean, I can drop the
`pull_request` trigger, or split `cargo test` into a separate
non-required job — just tell me which you prefer.

I have verified the three commands locally on Windows with the fixes
from #395 and #390 applied; I cannot exercise the Ubuntu runner from
here, so the apt/toolchain lines are mirrored from `release.yml` rather
than independently tested.
