### PR TITLE
fix(conversation): scope completed tool call ids to their round

### DIFF
--- a/server/src/cursor/conversation/output.rs
+++ b/server/src/cursor/conversation/output.rs
@@ -158,6 +158,7 @@ impl ConversationOutput {
         let mut streams = BTreeMap::<usize, ToolCallStream>::new();
         let mut completions = HashMap::<String, ToolCompletion>::new();
         let mut completed = HashSet::<String>::new();
+        let mut completed_round = None::<ToolRoundId>;
         let mut response_text = String::new();
         let mut response_thinking = String::new();
         let mut active_round = None::<ToolRoundId>;
@@ -425,6 +426,16 @@ impl ConversationOutput {
                         round_id,
                         calls: round_calls,
                     } => {
+                        // `completed` exists so that replaying ExecuteToolRound for a round
+                        // does not dispatch a call this round already committed. Tool call ids
+                        // are only unique *within* a round -- the schema says as much with
+                        // `UNIQUE (round_id, call_id)` -- so an id retained from an earlier
+                        // round would make start_batch skip a fresh call, and tool_round wait
+                        // forever for a result nothing will ever produce.
+                        if completed_round.as_ref() != Some(&round_id) {
+                            completed.clear();
+                            completed_round = Some(round_id.clone());
+                        }
                         active_round = Some(round_id.clone());
                         active_tool_calls = round_calls
                             .iter()

--- a/server/tests/tool_round.rs
+++ b/server/tests/tool_round.rs
@@ -1253,6 +1253,151 @@ fn client_run_for_model(
     }
 }
 
+/// A provider that reuses a tool call id across two rounds of the same run
+/// must not wedge the run. `ToolDispatcher::start_batch` skips any call whose
+/// id is already in `ToolBatchState::completed`, and that set is never cleared
+/// for the lifetime of the run, so the skipped call produced no completion and
+/// `tool_round::execute` waited forever for a result that could never arrive.
+#[tokio::test]
+async fn duplicate_tool_call_id_across_rounds_does_not_wedge_the_run() {
+    let (_directory, store) = fixtures::temp_store().await;
+    let provider = fake_provider::FakeProvider::default();
+    for _ in 0..2 {
+        provider.push(vec![
+            ModelEvent::Start {
+                model_call_id: "ignored".into(),
+            },
+            ModelEvent::ToolCallStart {
+                index: 0,
+                call_id: "call-1".into(),
+                name: "Read".into(),
+            },
+            ModelEvent::ToolCallArgumentsDelta {
+                index: 0,
+                delta: "{\"path\":\"/tmp/a\"}".into(),
+            },
+            ModelEvent::ToolCallEnd { index: 0 },
+            ModelEvent::Done(FinishReason::ToolUse),
+        ]);
+    }
+    provider.push(vec![
+        ModelEvent::Start {
+            model_call_id: "ignored".into(),
+        },
+        ModelEvent::TextStart,
+        ModelEvent::TextDelta("done".into()),
+        ModelEvent::TextEnd,
+        ModelEvent::Done(FinishReason::Stop),
+    ]);
+    let assets = PromptAssets::load(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("prompt/cursor")
+            .as_path(),
+    )
+    .unwrap();
+    let registry = TransportRegistry::new(
+        store.clone(),
+        Arc::new(provider.clone()),
+        PromptCompiler::new(assets),
+    );
+    let handle = registry.get_or_create("tool-request").await.unwrap();
+    let mut output = handle.subscribe();
+    handle
+        .command(TransportCommand::Append {
+            seqno: 0,
+            message: Box::new(client_run()),
+        })
+        .await
+        .unwrap();
+    let mut seqno = 1;
+    let mut execs = 0;
+    loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(10), output.recv())
+            .await
+            .expect("run must not hang on a reused tool call id")
+            .unwrap();
+        let (flags, payload) = connect::decode_frames(&frame).unwrap().pop().unwrap();
+        if flags & connect::END_STREAM_FLAG != 0 {
+            break;
+        }
+        let server = pb::AgentServerMessage::decode(payload).unwrap();
+        match server.message {
+            Some(pb::agent_server_message::Message::KvServerMessage(kv)) => {
+                handle
+                    .command(TransportCommand::Append {
+                        seqno,
+                        message: Box::new(kv_ack(kv.id)),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+            }
+            Some(pb::agent_server_message::Message::ExecServerMessage(exec)) => {
+                execs += 1;
+                let exec_id = exec.id;
+                handle
+                    .command(TransportCommand::Append {
+                        seqno,
+                        message: Box::new(pb::AgentClientMessage {
+                            message: Some(pb::agent_client_message::Message::ExecClientMessage(
+                                pb::ExecClientMessage {
+                                    id: exec_id,
+                                    exec_id: String::new(),
+                                    message: Some(pb::exec_client_message::Message::ReadResult(
+                                        pb::ReadResult {
+                                            result: Some(pb::read_result::Result::Success(
+                                                pb::ReadSuccess {
+                                                    path: "/tmp/a".into(),
+                                                    total_lines: 1,
+                                                    file_size: 1,
+                                                    output: Some(
+                                                        pb::read_success::Output::Content(
+                                                            "x".into(),
+                                                        ),
+                                                    ),
+                                                    ..Default::default()
+                                                },
+                                            )),
+                                        },
+                                    )),
+                                    ..Default::default()
+                                },
+                            )),
+                        }),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+                handle
+                    .command(TransportCommand::Append {
+                        seqno,
+                        message: Box::new(pb::AgentClientMessage {
+                            message: Some(
+                                pb::agent_client_message::Message::ExecClientControlMessage(
+                                    pb::ExecClientControlMessage {
+                                        message: Some(
+                                            pb::exec_client_control_message::Message::StreamClose(
+                                                pb::ExecClientStreamClose { id: exec_id },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        }),
+                    })
+                    .await
+                    .unwrap();
+                seqno += 1;
+            }
+            _ => {}
+        }
+    }
+    // Both rounds have to reach the client, and the run has to get far enough
+    // to ask the provider a third time and finish.
+    assert_eq!(execs, 2);
+    assert_eq!(provider.requests().len(), 3);
+}
+
 fn client_run() -> pb::AgentClientMessage {
     let user = pb::UserMessage {
         text: "read it".into(),


### PR DESCRIPTION
## Problem

If a provider emits the same tool call id in two different rounds of one
run, the run wedges permanently: the second call is never dispatched, no
result is ever produced, and the stream never closes. The client sees the
tool call appear and then sit there forever.

There is no timeout anywhere on this path, so it does not recover on its
own. The only escape is sending another user message, which routes
`RunCommand::BreakMessages` into `tool_round.rs` and synthesizes
interrupted results for the outstanding calls.

## Root cause

`ToolDispatcher::start_batch` skips any call whose id is already
completed (`server/src/cursor/tools/mod.rs:101`):

```rust
for (position, call) in calls.iter().enumerate() {
    if state.completed.contains(&call.call_id) {
        continue;
    }
```

Skipping means no exec message and no `ToolCompletion`. Meanwhile the run
core is blocked in `server/src/run/tool_round.rs:74-81` waiting for
exactly `calls.len()` results, and `remaining -= 1` only happens on
`RunCommand::ToolResult`. Nothing else decrements it and nothing times
out, so the round can never settle.

The set feeding that check is created once per run
(`server/src/cursor/conversation/output.rs:160`) and is never cleared:

```rust
let mut completed = HashSet::<String>::new();
```

So it is **run**-scoped, while a tool call id is only unique **within a
round**. The schema already states that scope explicitly —
`server/migrations/0001_initial.sql:106`:

```sql
UNIQUE (round_id, call_id),
```

A cross-round duplicate therefore inserts into the database perfectly
happily, and only the in-memory `completed` set treats it as a repeat.

Worth noting that the sibling completed-map on the tool runtime *is*
already reset at the round boundary (`output.rs:615`,
`self.tool_runtime.clear_completed()`). This `HashSet` is the one that
was missed.

## How a provider ends up reusing an id

`server/src/provider/openai_chat.rs:196` synthesizes ids for providers
that omit them:

```rust
if tool.call_id.is_empty() {
    tool.call_id = format!("call-{index}");
}
```

`tools` is declared inside `stream()` (`openai_chat.rs:123`), so `index`
restarts at 0 for every model call. Against an OpenAI-compatible endpoint
that consistently omits `id` in streaming `tool_calls` deltas, the second
tool round of essentially every run collides on `call-0`.

The per-cycle guard at `server/src/run/model_cycle.rs:50` does not catch
this — its `call_ids` set is created fresh per cycle, so it only rejects
reuse *within* one response.

`anthropic.rs:163` and `openai_responses.rs:317` both require a
provider-supplied id and error without one, so `openai_chat` is the only
synthesis site. I have left it alone here: with `completed` scoped
correctly the synthesized ids are no longer harmful, and #391 is already
touching that file. Happy to follow up separately if you would rather the
ids were unique at the source too.

## Fix

Scope `completed` to the round it describes. `ExecuteToolRound` clears it
when a new `round_id` begins, tracked independently of `active_round` so
it does not depend on the order in which `ToolRoundStarted` and
`ExecuteToolRound` are observed.

This preserves the reason the set exists — replaying `ExecuteToolRound`
for the *same* round still skips calls that round already committed — and
drops only the cross-round retention that caused the stall.
`start_batch` has exactly one production call site, so the change is
contained to that path.

## Verification

The new test drives the real transport end to end with a provider that
returns `call-1` twice in a row, then a plain text response.

```
# before (fix reverted, test kept)
$ cargo test -p cursor-server --test tool_round duplicate_tool_call_id
test duplicate_tool_call_id_across_rounds_does_not_wedge_the_run ... FAILED
panicked at server/tests/tool_round.rs:999:14:
  run must not hang on a reused tool call id: Elapsed(())
test result: FAILED. 0 passed; 1 failed
finished in 10.30s          # the full 10s timeout, i.e. the hang

# after
$ cargo test -p cursor-server --test tool_round
test duplicate_tool_call_id_across_rounds_does_not_wedge_the_run ... ok
test result: ok. 15 passed; 0 failed
finished in 0.42s
```

Full suite, and `fmt` clean for the two files this touches. The one
unrelated failure below is pre-existing on `main` and is what #390 fixes:

```
$ cargo test --workspace --all-targets
11 suites ok; 1 failure, local_rules_context::local_markdown_rules_land_in_the_request_context_message
(identical before and after this branch)

$ cargo fmt --all -- --check     # no diff in output.rs or tool_round.rs
```

Note on `clippy`: this branch is cut from `main`, which currently has
four pre-existing `clippy` errors (fixed in #395). This PR introduces no
new ones.
