### PR TITLE
fix(tools): report the ReadLints paths that were never checked

### DIFF
--- a/server/src/cursor/tools/tool_call_result/exec/output.rs
+++ b/server/src/cursor/tools/tool_call_result/exec/output.rs
@@ -12,7 +12,7 @@ pub(super) fn output(
         Message::WriteResult(value) => write(value),
         Message::DeleteResult(value) => delete(value),
         Message::GrepResult(value) => grep(value),
-        Message::DiagnosticsResult(value) => diagnostics(value),
+        Message::DiagnosticsResult(value) => diagnostics(value, call),
         Message::McpResult(value) => mcp(value),
         Message::ReadMcpResourceExecResult(value) => read_mcp(value),
         Message::SubagentResult(value) => task(value, call),
@@ -212,14 +212,14 @@ fn grep_truncation(
     }
 }
 
-fn diagnostics(value: &pb::DiagnosticsResult) -> Result<(String, bool)> {
+fn diagnostics(value: &pb::DiagnosticsResult, call: &ToolCall) -> Result<(String, bool)> {
     use pb::diagnostics_result::Result as R;
     match value
         .result
         .as_ref()
         .ok_or_else(|| missing("diagnostics"))?
     {
-        R::Success(value) => Ok((diagnostics_success(value), false)),
+        R::Success(value) => Ok((diagnostics_success(value, call), false)),
         R::Error(value) => Ok((value.error.clone(), true)),
         R::Rejected(value) => Ok((value.reason.clone(), true)),
         R::FileNotFound(value) => Ok((format!("file not found: {}", value.path), true)),
@@ -227,9 +227,40 @@ fn diagnostics(value: &pb::DiagnosticsResult) -> Result<(String, bool)> {
     }
 }
 
-fn diagnostics_success(value: &pb::DiagnosticsSuccess) -> String {
+/// `codec::request` encodes only `paths[0]` into the `DiagnosticsArgs` exec, and
+/// `DiagnosticsSuccess` carries a single `path`, so a multi-path ReadLints call
+/// only ever inspects the first entry. Name the rest instead of letting a clean
+/// result for one file read as a clean bill of health for all of them.
+fn unchecked_lint_paths(call: &ToolCall) -> Vec<&str> {
+    call.arguments
+        .get("paths")
+        .and_then(serde_json::Value::as_array)
+        .map(|paths| {
+            paths
+                .iter()
+                .skip(1)
+                .filter_map(serde_json::Value::as_str)
+                .filter(|path| !path.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn diagnostics_success(value: &pb::DiagnosticsSuccess, call: &ToolCall) -> String {
+    let unchecked = unchecked_lint_paths(call);
+    let notice = (!unchecked.is_empty()).then(|| {
+        format!(
+            "[Only {} was checked; ReadLints reads one path per call. Not checked: {}]",
+            value.path,
+            unchecked.join(", ")
+        )
+    });
     if value.diagnostics.is_empty() {
-        return format!("No diagnostics found in {}", value.path);
+        let clean = format!("No diagnostics found in {}", value.path);
+        return match notice {
+            Some(notice) => format!("{clean}\n{notice}"),
+            None => clean,
+        };
     }
     let mut lines = value
         .diagnostics
@@ -261,6 +292,7 @@ fn diagnostics_success(value: &pb::DiagnosticsSuccess) -> String {
             value.diagnostics.len()
         ));
     }
+    lines.extend(notice);
     lines.join("\n")
 }
 
@@ -412,4 +444,83 @@ fn creates_subagent(call: &ToolCall) -> bool {
 
 fn missing(name: &str) -> Error {
     Error::Protocol(format!("{name} returned no result"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn read_lints(paths: serde_json::Value) -> ToolCall {
+        ToolCall {
+            index: 0,
+            call_id: "lints".into(),
+            model_call_id: "model:0".into(),
+            name: "ReadLints".into(),
+            arguments_text: String::new(),
+            arguments: json!({ "paths": paths }),
+        }
+    }
+
+    fn clean_result(path: &str) -> pb::exec_client_message::Message {
+        pb::exec_client_message::Message::DiagnosticsResult(pb::DiagnosticsResult {
+            result: Some(pb::diagnostics_result::Result::Success(
+                pb::DiagnosticsSuccess {
+                    path: path.into(),
+                    diagnostics: Vec::new(),
+                    total_diagnostics: 0,
+                },
+            )),
+        })
+    }
+
+    /// The codec encodes only `paths[0]` into the DiagnosticsArgs exec, so a
+    /// clean result for that one path must not read as "these files are all
+    /// clean" for the paths that were never looked at.
+    #[test]
+    fn read_lints_names_the_paths_it_did_not_check() {
+        let call = read_lints(json!(["a.ts", "b.ts", "c.ts"]));
+        let (content, is_error) = output(&clean_result("a.ts"), &call).unwrap();
+        assert!(!is_error);
+        assert!(content.contains("a.ts"));
+        assert!(
+            content.contains("b.ts") && content.contains("c.ts"),
+            "unchecked paths must be reported, got: {content}"
+        );
+    }
+
+    /// The overwhelmingly common single-path call must be byte-for-byte
+    /// unchanged.
+    #[test]
+    fn read_lints_single_path_result_is_unchanged() {
+        let call = read_lints(json!(["a.ts"]));
+        let (content, _) = output(&clean_result("a.ts"), &call).unwrap();
+        assert_eq!(content, "No diagnostics found in a.ts");
+    }
+
+    /// The notice belongs on a result that did report diagnostics too: those
+    /// diagnostics are still only a.ts's.
+    #[test]
+    fn read_lints_reports_unchecked_paths_alongside_diagnostics() {
+        let call = read_lints(json!(["a.ts", "b.ts"]));
+        let message = pb::exec_client_message::Message::DiagnosticsResult(pb::DiagnosticsResult {
+            result: Some(pb::diagnostics_result::Result::Success(
+                pb::DiagnosticsSuccess {
+                    path: "a.ts".into(),
+                    diagnostics: vec![pb::Diagnostic {
+                        message: "unused import".into(),
+                        severity: pb::DiagnosticSeverity::Warning as i32,
+                        ..Default::default()
+                    }],
+                    total_diagnostics: 1,
+                },
+            )),
+        });
+        let (content, _) = output(&message, &call).unwrap();
+        assert!(content.contains("unused import"));
+        assert!(
+            content.contains("Not checked: b.ts"),
+            "unchecked paths must be reported, got: {content}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`ReadLints` takes an array of paths, but only the first one is ever
looked at — and the result does not say so. The model asks about three
files, one is checked, and it is told the check came back clean.

`server/src/cursor/tools/codec/request.rs:109-119`:

```rust
"readlints" => Message::DiagnosticsArgs(pb::DiagnosticsArgs {
    path: call
        .arguments
        .get("paths")
        .and_then(Value::as_array)
        .and_then(|paths| paths.first())   // paths[1..] discarded here
        .and_then(Value::as_str)
        .unwrap_or_default()
        .into(),
    tool_call_id: call.call_id.clone(),
}),
```

Nothing downstream compensates. For `{"paths": ["a.ts", "b.ts", "c.ts"]}`
the model receives, verbatim:

```
No diagnostics found in a.ts
```

with `is_error: false`. The existing truncation notice cannot fire here —
it compares `total_diagnostics` against `diagnostics.len()`, which is a
per-file count (`output.rs:257-263`). The UI half is inconsistent in the
same direction: `render.rs:366-378` echoes all three paths into
`ReadLintsToolArgs`, while `render.rs:126-134` returns a one-element
`file_diagnostics` and a hardcoded `total_files: 1`.

So the worst reading is the one the model actually gets: **b.ts and c.ts
are reported clean without ever having been opened.**

This is not a regression — `git log -L 109,119` shows the line has been
this way since `4053a7f`. There is no test covering the ReadLints codec.

## Why it is shaped this way

The two protocol layers genuinely disagree, which is worth stating
plainly because it constrains the fix.

The exec layer is single-path, and cannot express more
(`protocols/cursor/agent_v1.proto:2167`, `:2206`):

```proto
message DiagnosticsArgs   { string path = 1; string tool_call_id = 2; }
message DiagnosticsSuccess { string path = 1; repeated Diagnostic diagnostics = 2; int32 total_diagnostics = 3; }
```

The tool layer is multi-path (`:5214`, `:5238`):

```proto
message ReadLintsToolArgs    { repeated string paths = 1; }
message ReadLintsToolSuccess { repeated FileDiagnostics file_diagnostics = 1; int32 total_files = 2; ... }
```

`repeated FileDiagnostics` plus a `total_files` counter is a result shape
built for N files, so upstream presumably fans out N `DiagnosticsArgs`
execs and aggregates. `server/prompt/cursor/tools.json` advertises the
array to the model as well.

## What this PR does — and does not — do

It makes the result honest, and nothing else. When the call carried more
than one path, the model-facing text names the ones that were not read:

```
No diagnostics found in a.ts
[Only a.ts was checked; ReadLints reads one path per call. Not checked: b.ts, c.ts]
```

That follows the bracketed-notice convention already in this file
(`[Results truncated; ...]`, `[Reported N diagnostics; received M details]`)
and uses the seam that already exists — `output(message, call)` is handed
the original `ToolCall`, exactly as `task(value, call)` and
`render::read(result, call)` already use it. Single-path calls, which are
surely the common case, are byte-for-byte unchanged.

**I deliberately did not implement the fan-out.** Doing it properly means
reserving N exec ids per call, aggregating N `DiagnosticsResult`s into
one `ReadLintsToolSuccess`, and adding a completion barrier — `take_exec`
currently removes the pending entry on the first result
(`runtime.rs:237-246`), so there is nowhere to accumulate partial ones.
That is roughly the size of the existing `EditRead`/`EditWrite` staging
machinery and is a feature, not a patch. Happy to take it on in a
follow-up if you want it — this PR is meant to stop the misinformation in
the meantime, not to close the capability gap.

I also considered simply erroring when `paths.len() > 1`. I did not,
because the tool's own description invites the array, so erroring would
break a documented call the model is actively encouraged to make.

The notice is added on the success path only. The error paths
(`FileNotFound`, `PermissionDenied`, ...) already return `is_error: true`,
so they do not carry the "everything is fine" implication that motivates
this change.

## Verification

```
# before (fix reverted, tests kept)
$ cargo test -p cursor-server --lib read_lints
test read_lints_single_path_result_is_unchanged ... ok
test read_lints_names_the_paths_it_did_not_check ... FAILED
panicked at output.rs:454:
  unchecked paths must be reported, got: No diagnostics found in a.ts
test result: FAILED. 1 passed; 1 failed

# after
$ cargo test -p cursor-server --lib read_lints
test read_lints_names_the_paths_it_did_not_check ... ok
test read_lints_single_path_result_is_unchanged ... ok
test read_lints_reports_unchecked_paths_alongside_diagnostics ... ok
test result: ok. 3 passed; 0 failed
```

Full suite and lints:

```
$ cargo test --workspace --all-targets
11 suites ok; 1 failure, local_rules_context::local_markdown_rules_land_in_the_request_context_message
(pre-existing on main, unrelated to this branch, fixed by #390)

$ cargo fmt --all -- --check       # no diff in output.rs

$ cargo clippy --workspace --all-targets -- -D warnings
the 4 pre-existing errors on main only (data.rs x2, openai_responses.rs,
store/models.rs -- all fixed by #395); none in output.rs
```

This adds the first `#[cfg(test)]` module to `output.rs`; it is placed at
the end of the file so `clippy::items_after_test_module` stays happy.
