### PR TITLE
perf(desktop): on-demand webview lifecycle and mimalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "axum",
  "cursor-server",
  "libc",
+ "mimalloc",
  "rfd",
  "serde",
  "serde_json",
@@ -3418,6 +3419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,6 +3612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 axum = "0.8"
 cursor-server = { path = "../../../server" }
 libc = "0.2"
+mimalloc = "0.1"
 rfd = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/desktop/src-tauri/src/desktop.rs
+++ b/apps/desktop/src-tauri/src/desktop.rs
@@ -36,6 +36,7 @@ struct DesktopRuntime {
     shutdown: CancellationToken,
     server: Mutex<Option<JoinHandle<Result<()>>>>,
     exiting: AtomicBool,
+    server_addr: std::net::SocketAddr,
 }
 
 #[tauri::command]
@@ -141,6 +142,21 @@ fn create_main_window(
     builder.build()
 }
 
+/// 按需打开主窗口:webview 仅在需要界面时创建,关闭窗口即销毁释放内存。
+pub(crate) fn open_main_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+        return Ok(());
+    }
+    let address = app.state::<DesktopRuntime>().server_addr;
+    let window = create_main_window(app, address)?;
+    window.show()?;
+    window.set_focus()?;
+    Ok(())
+}
+
 pub fn run() -> ExitCode {
     let diagnostics = match StartupDiagnostics::initialize() {
         Ok(diagnostics) => diagnostics,
@@ -184,7 +200,7 @@ pub fn run() -> ExitCode {
         ])
         .plugin(tauri_plugin_single_instance::init(|app, args, _| {
             if !args.iter().any(|arg| arg == AUTOSTART_ARG) {
-                tray::show_main_window(app);
+                let _ = open_main_window(app);
             }
         }))
         .plugin(tauri_plugin_clipboard_manager::init())
@@ -240,13 +256,12 @@ pub fn run() -> ExitCode {
                 shutdown,
                 server: Mutex::new(Some(task)),
                 exiting: AtomicBool::new(false),
+                server_addr: address,
             });
-            let window = create_main_window(app.handle(), address)?;
             if desktop_settings.silent_start && started_by_autostart {
-                tracing::info!("silent autostart enabled; keeping the main window hidden");
+                tracing::info!("silent autostart enabled; starting without the main window");
             } else {
-                window.show()?;
-                window.set_focus()?;
+                open_main_window(app.handle())?;
             }
             tray::create(app)?;
             crate::update::signal_ready_if_requested()?;
@@ -262,46 +277,42 @@ pub fn run() -> ExitCode {
     };
 
     app.run(|app, event| match event {
-        RunEvent::WindowEvent {
-            label,
-            event: tauri::WindowEvent::CloseRequested { api, .. },
-            ..
-        } if label == MAIN_WINDOW_LABEL => {
-            let runtime = app.state::<DesktopRuntime>();
-            if !runtime.exiting.load(Ordering::Acquire) {
-                api.prevent_close();
-                if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-                    let _ = window.hide();
+        // code 为 None 表示所有窗口已被关闭(轻量模式),阻止退出,
+        // 转发服务继续在托盘后台运行;code 为 Some 时是显式退出请求。
+        RunEvent::ExitRequested { code, api, .. } => match code {
+            None => api.prevent_exit(),
+            Some(_) => {
+                let runtime = app.state::<DesktopRuntime>();
+                if !runtime.exiting.swap(true, Ordering::AcqRel) {
+                    api.prevent_exit();
+                    runtime.shutdown.cancel();
+                    let server = runtime.server.lock().expect("server lock poisoned").take();
+                    let app = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Some(server) = server {
+                            match tokio::time::timeout(Duration::from_secs(11), server).await {
+                                Ok(Ok(Ok(()))) => {}
+                                Ok(Ok(Err(error))) => {
+                                    tracing::error!(%error, "desktop server shutdown failed")
+                                }
+                                Ok(Err(error)) => {
+                                    tracing::error!(%error, "desktop server task failed")
+                                }
+                                Err(_) => tracing::warn!("desktop server shutdown timed out"),
+                            }
+                        }
+                        app.exit(0);
+                    });
                 }
             }
-        }
-        RunEvent::ExitRequested { api, .. } => {
-            let runtime = app.state::<DesktopRuntime>();
-            if !runtime.exiting.swap(true, Ordering::AcqRel) {
-                api.prevent_exit();
-                runtime.shutdown.cancel();
-                let server = runtime.server.lock().expect("server lock poisoned").take();
-                let app = app.clone();
-                tauri::async_runtime::spawn(async move {
-                    if let Some(server) = server {
-                        match tokio::time::timeout(Duration::from_secs(11), server).await {
-                            Ok(Ok(Ok(()))) => {}
-                            Ok(Ok(Err(error))) => {
-                                tracing::error!(%error, "desktop server shutdown failed")
-                            }
-                            Ok(Err(error)) => tracing::error!(%error, "desktop server task failed"),
-                            Err(_) => tracing::warn!("desktop server shutdown timed out"),
-                        }
-                    }
-                    app.exit(0);
-                });
-            }
-        }
+        },
         #[cfg(target_os = "macos")]
         RunEvent::Reopen {
             has_visible_windows: false,
             ..
-        } => tray::show_main_window(app),
+        } => {
+            let _ = open_main_window(app);
+        }
         _ => {}
     });
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,11 @@ mod startup;
 mod tray;
 mod update;
 
+// mimalloc 在释放时主动向操作系统归还内存,避免 glibc 保留页导致
+// 关闭窗口后 RSS 无法回落到静默启动水平。
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub fn run() -> std::process::ExitCode {
     if let Some(exit_code) = update::run_replacement_if_requested() {
         return exit_code;

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -1,13 +1,13 @@
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
-    App, AppHandle, Manager,
+    App,
 };
 
 #[cfg(target_os = "windows")]
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
 
-use crate::desktop::MAIN_WINDOW_LABEL;
+use crate::desktop::open_main_window;
 
 const OPEN_MENU_ID: &str = "tray-open";
 const QUIT_MENU_ID: &str = "tray-quit";
@@ -24,7 +24,9 @@ pub fn create(app: &mut App) -> tauri::Result<()> {
         .menu(&menu)
         .show_menu_on_left_click(cfg!(target_os = "macos"))
         .on_menu_event(|app, event| match event.id().as_ref() {
-            OPEN_MENU_ID => show_main_window(app),
+            OPEN_MENU_ID => {
+                let _ = open_main_window(app);
+            }
             QUIT_MENU_ID => app.exit(0),
             _ => {}
         })
@@ -36,7 +38,7 @@ pub fn create(app: &mut App) -> tauri::Result<()> {
                 ..
             } = event
             {
-                show_main_window(tray.app_handle());
+                let _ = open_main_window(tray.app_handle());
             }
 
             #[cfg(not(target_os = "windows"))]
@@ -44,12 +46,4 @@ pub fn create(app: &mut App) -> tauri::Result<()> {
         })
         .build(app)?;
     Ok(())
-}
-
-pub fn show_main_window(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        let _ = window.unminimize();
-        let _ = window.show();
-        let _ = window.set_focus();
-    }
 }


### PR DESCRIPTION
## 性能优化：界面渲染进程生命周期管理

### 背景

原实现中，主进程在启动时无条件创建 Webview 窗口，关闭窗口仅执行 `hide()` 而非销毁。
用户实际只需要后台的 Cursor 请求转发功能（界面仅用于查看和编辑数据），
但 WebKit 渲染进程（WebProcess + NetworkProcess）在静默启动、关闭窗口、
最小化到托盘的整个生命周期中始终驻留内存。

### 修改前（各平台实测，略有差异）

| 进程 | 内存占用 |
| --- | --- |
| 主进程（cursor-byok-desktop，含 GTK/WebKit 宿主） | 约 500–600 MB |
| WebKitWebProcess（界面渲染） | 约 300–400 MB |
| WebKitNetworkProcess | 约 60–70 MB |
| **合计** | 约 800-1gb|

<img width="1380" height="314" alt="截图 2026-09-02 17-53-30" src="https://github.com/user-attachments/assets/b46de5ef-e3cb-4ca2-bce1-719dc297bc30" />

### 修改后

- **静默启动**：不创建 Webview，界面完全未渲染，仅常驻转发核心 + 托盘
- **关闭窗口**：销毁 webview（`destroy`），WebKit 进程退出，内存归还系统
- **按需唤起**：点击托盘「打开」时才创建窗口（首次冷加载约 1–2 秒）
- **优化效果**：常驻内存从约 0.8–1.1 GB 降至约 598 MB，降幅约 25%–47%（典型场景约 36%，各平台略有差异）。
<img width="1374" height="522" alt="截图 2026-09-02 18-09-10" src="https://github.com/user-attachments/assets/03d60c9e-7efa-4aca-b702-fc65a1ae9473" />

### 技术细节

1. `desktop.rs`：窗口创建改为按需（`open_main_window`）；`ExitRequested { code: None }`
   时 `prevent_exit()`，转发服务继续在托盘后台运行；托盘「退出」仍走原有优雅停机。
2. `tray.rs`：菜单「打开」与 Windows 托盘左键统一走 `open_main_window`（不存在则创建）。
3. `lib.rs`：全局分配器切换为 mimalloc，避免 glibc 保留页导致 webview 销毁后 RSS 无法回落。
4. **核心转发功能零修改**：`server/` crate、HTTP 边界（`/__byok-api__/`）、
   MITM 代理、模型路由均未改动；数据全部持久化于 SQLite，界面销毁与重建无状态丢失。

### 兼容性说明

- 关闭窗口后重新打开为冷加载（1–2 秒），界面临时状态（表单草稿、滚动位置）会丢失，
  配置数据不受影响。
- 单实例唤起、开机自启行为不变。