### PR TITLE
chore: restore a green make check on main

### DIFF
--- a/apps/desktop/src-tauri/src/update/mod.rs
+++ b/apps/desktop/src-tauri/src/update/mod.rs
@@ -57,9 +57,9 @@ pub(crate) async fn check_portable_update(
     #[cfg(target_os = "windows")]
     {
         let update = portable_update(&app).await?;
-        return Ok(update.map(|update| PortableUpdateInfo {
+        Ok(update.map(|update| PortableUpdateInfo {
             version: update.version,
-        }));
+        }))
     }
     #[cfg(not(target_os = "windows"))]
     {

--- a/server/src/cursor/conversation/runtime.rs
+++ b/server/src/cursor/conversation/runtime.rs
@@ -172,9 +172,9 @@ impl ConversationRuntime {
                         break;
                     }
                     TransportCommand::RunFinished { generation, finish } => {
-                        if !current
+                        if current
                             .as_ref()
-                            .is_some_and(|current| current.id == generation)
+                            .is_none_or(|current| current.id != generation)
                         {
                             continue;
                         }

--- a/server/src/cursor/tools/tool_call_result/exec/output.rs
+++ b/server/src/cursor/tools/tool_call_result/exec/output.rs
@@ -459,6 +459,7 @@ mod tests {
             name: "ReadLints".into(),
             arguments_text: String::new(),
             arguments: json!({ "paths": paths }),
+            argument_error: None,
         }
     }
 

--- a/server/tests/connect_wire.rs
+++ b/server/tests/connect_wire.rs
@@ -21,6 +21,7 @@ use cursor_server::{
         proto::{agent::v1 as pb, aiserver::v1 as ai},
     },
     cursor::transport::TransportRegistry,
+    network::NetworkClients,
 };
 use flate2::{write::GzEncoder, Compression};
 use prost::Message;
@@ -102,6 +103,7 @@ async fn bidi_append_gzip_body_is_decompressed_before_protobuf_decode() {
             .as_path(),
     )
     .unwrap();
+    let clients = NetworkClients::new(store.clone());
     let registry = TransportRegistry::new(
         store,
         Arc::new(fake_provider::FakeProvider::default()),
@@ -118,7 +120,7 @@ async fn bidi_append_gzip_body_is_decompressed_before_protobuf_decode() {
     encoder.write_all(&wire).unwrap();
     let compressed = encoder.finish().unwrap();
 
-    let response = cursor::router(registry)
+    let response = cursor::router(registry, clients)
         .unwrap()
         .oneshot(
             Request::post("/aiserver.v1.BidiService/BidiAppend")


### PR DESCRIPTION
## Problem

`make check` does not pass on a clean checkout of `main` (`8fdcdd7`). Four
independent breaks, from four commits that were each fine on their own tree
but were never built together:

| # | where | what | introduced by |
|---|---|---|---|
| 1 | `server/src/cursor/tools/tool_call_result/exec/output.rs:455` | the `read_lints` test helper builds `ToolCall { .. }` without `argument_error` — the **`cursor-server` lib-test target does not compile**, so `cargo test --lib` / `--workspace` die at build | **my #398** (`e1d6bd9`), written before `d83e14a` added the field and merged after it |
| 2 | `server/tests/connect_wire.rs:121` | `cursor::router(registry)` — the function now takes a second `NetworkClients` argument; the `connect_wire` suite does not compile | `2dad593` |
| 3 | `server/src/cursor/conversation/runtime.rs:175` | `clippy::nonminimal_bool` (`!x.is_some_and(..)`) | `5cdf642` |
| 4 | `apps/desktop/src-tauri/src/update/mod.rs:60` | `clippy::needless_return` inside the `#[cfg(target_os = "windows")]` arm, so it only shows up when clippy runs on Windows | `ddaa61c` |

To be plain about #1: that one is mine. #398 was reviewed against the tree
before `d83e14a`, and I did not re-run the gate after the two landed
together. Sorry for the noise.

Exact output on `8fdcdd7`:

```
$ cargo clippy --workspace --all-targets -- -D warnings
error[E0063]: missing field `argument_error` in initializer of `model::tool::ToolCall`
   --> server\src\cursor\tools\tool_call_result\exec\output.rs:455:9
error: could not compile `cursor-server` (lib test) due to 1 previous error
error: this boolean expression can be simplified
   --> server\src\cursor\conversation\runtime.rs:175:28
error: could not compile `cursor-server` (lib) due to 1 previous error
(exit 101)

$ cargo test -p cursor-server --test connect_wire --no-run
error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> server\tests\connect_wire.rs:121:20
error: could not compile `cursor-server` (test "connect_wire") due to 1 previous error
(exit 101)
```

and once the three server breaks are fixed clippy gets one crate further:

```
error: unneeded `return` statement
  --> apps\desktop\src-tauri\src\update\mod.rs:60:9
error: could not compile `cursor-byok-desktop` (lib) due to 1 previous error
```

## Fix

Four mechanical repairs, one per diagnostic, no `#[allow]` anywhere:

- **`output.rs`** — `argument_error: None,` in the test helper, the same
  line every other `ToolCall` literal in the tests carries.
- **`connect_wire.rs`** — build `NetworkClients::new(store.clone())` before
  the registry and pass it, exactly how `app.rs` wires the real router and
  how `knowledge_rules.rs` already constructs one in tests.
- **`runtime.rs`** — clippy's own suggestion,
  `current.as_ref().is_none_or(|current| current.id != generation)`; the
  same `is_none_or` shape is used ten lines above.
- **`update/mod.rs`** — drop the `return`, making the Windows block the
  tail expression the way the non-Windows block already is.

No behaviour changes.

## Verification

All on Windows, Rust 1.95, this branch (`8fdcdd7` + these four files):

```
$ cargo fmt --all -- --check
(clean, exit 0)

$ cargo clippy --workspace --all-targets -- -D warnings
(clean, exit 0)

$ cargo test --workspace --no-fail-fast
cursor-byok-desktop (lib) ....... 6 passed
cursor-server (lib) ............. 85 passed     <- did not compile before
checkpoint_recovery ............. 4 passed
compaction ...................... 4 passed
connect_wire .................... 6 passed     <- did not compile before
conversation_delivery ........... 4 passed
cursor_trace_queue .............. 2 passed
cursor_transport_lifecycle ...... 2 passed
error_lifecycle ................. 7 passed
interrupt ....................... 17 passed
knowledge_rules ................. 2 passed
local_rules_context ............. 1 FAILED     <- pre-existing, see below
prefix_stability ................ 13 passed
tool_round ...................... 17 passed
semble-benchmark ................ 10 passed
semble-core ..................... 37 passed
```

The single remaining failure is
`local_rules_context::local_markdown_rules_land_in_the_request_context_message`.
It is the same timeout that #390 fixes, it fails identically without this
PR, and I have deliberately not touched it here. With #390 and this PR the
three Rust gates in `make check` are green.

