### PR TITLE
fix(run): stop retrying provider responses that cannot succeed

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     Protocol(String),
     #[error("provider error: {0}")]
     Provider(String),
+    #[error("provider error: {message}")]
+    ProviderStatus { status: StatusCode, message: String },
     #[error("store error: {0}")]
     Store(String),
     #[error("run was cancelled")]
@@ -48,7 +50,9 @@ impl IntoResponse for Error {
                 StatusCode::BAD_REQUEST
             }
             Self::RunNotFound(_) => StatusCode::NOT_FOUND,
-            Self::Provider(_) | Self::Http(_) => StatusCode::BAD_GATEWAY,
+            Self::Provider(_) | Self::ProviderStatus { .. } | Self::Http(_) => {
+                StatusCode::BAD_GATEWAY
+            }
             Self::Cancelled => StatusCode::CONFLICT,
             Self::Store(_)
             | Self::Database(_)

--- a/server/src/provider/attempt.rs
+++ b/server/src/provider/attempt.rs
@@ -38,10 +38,10 @@ where
         _ = cancellation.cancelled() => return Ok(Attempt::Cancelled),
         bytes = response.bytes() => bytes,
     }?;
-    Err(Error::Provider(format!(
-        "{label} {status}: {}",
-        String::from_utf8_lossy(&bytes)
-    )))
+    Err(Error::ProviderStatus {
+        status,
+        message: format!("{label} {status}: {}", String::from_utf8_lossy(&bytes)),
+    })
 }
 
 #[cfg(test)]
@@ -69,9 +69,13 @@ mod tests {
         let error = send_once("test", || client.get(&url), &CancellationToken::new(), None)
             .await
             .unwrap_err();
-        assert!(
-            matches!(error, Error::Provider(message) if message.contains("503") && message.contains("down"))
-        );
+        assert!(matches!(
+            error,
+            Error::ProviderStatus { status, message }
+                if status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+                    && message.contains("503")
+                    && message.contains("down")
+        ));
     }
 
     #[tokio::test]

--- a/server/src/provider/recorder.rs
+++ b/server/src/provider/recorder.rs
@@ -365,7 +365,9 @@ fn finish_reason(reason: FinishReason) -> &'static str {
 
 fn error_kind(error: &crate::Error) -> &'static str {
     match error {
-        crate::Error::Provider(_) | crate::Error::Http(_) => "provider",
+        crate::Error::Provider(_) | crate::Error::ProviderStatus { .. } | crate::Error::Http(_) => {
+            "provider"
+        }
         crate::Error::Cancelled => "cancelled",
         crate::Error::Database(_) | crate::Error::Store(_) => "store",
         _ => "internal",

--- a/server/src/run/event.rs
+++ b/server/src/run/event.rs
@@ -30,7 +30,9 @@ impl From<crate::Error> for RunFailure {
         use crate::Error;
         match error {
             Error::Protocol(message) | Error::Config(message) => Self::Protocol(message),
-            Error::Provider(message) => Self::Provider(message),
+            Error::Provider(message) | Error::ProviderStatus { message, .. } => {
+                Self::Provider(message)
+            }
             Error::Store(message) => Self::Store(message),
             Error::Cancelled => Self::Client("run was cancelled".into()),
             Error::Http(error) => Self::Provider(error.to_string()),

--- a/server/src/run/model_cycle.rs
+++ b/server/src/run/model_cycle.rs
@@ -10,7 +10,7 @@ use crate::{
     provider::{FinishReason, ModelEvent, ProviderStream},
 };
 
-use super::{RunEvent, RunFailure};
+use super::{model_retry::is_permanent_rejection, RunEvent, RunFailure};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModelCycleResult {
@@ -84,6 +84,9 @@ pub async fn consume_model_cycle(
         };
         let event = match next {
             Ok(event) => event,
+            Err(error) if is_permanent_rejection(&error) => {
+                return Err(terminal_failure(error.into(), text, reasoning, usage));
+            }
             Err(error) => {
                 return Err(failure(error.into(), text, reasoning, usage));
             }
@@ -405,7 +408,48 @@ mod tests {
         model::Usage,
         provider::{FinishReason, ModelEvent},
     };
+    use axum::http::StatusCode;
     use tokio_stream::wrappers::ReceiverStream;
+
+    #[tokio::test]
+    async fn rejected_provider_requests_are_terminal() {
+        let failure = consume_failure(status_error(StatusCode::UNAUTHORIZED)).await;
+
+        assert!(!failure.retryable);
+        assert!(matches!(
+            failure.failure,
+            RunFailure::Provider(message) if message == "test 401 Unauthorized"
+        ));
+    }
+
+    #[tokio::test]
+    async fn overloaded_provider_requests_stay_retryable() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            assert!(
+                consume_failure(status_error(status)).await.retryable,
+                "{status}"
+            );
+        }
+    }
+
+    fn status_error(status: StatusCode) -> crate::Error {
+        crate::Error::ProviderStatus {
+            status,
+            message: format!("test {status}"),
+        }
+    }
+
+    async fn consume_failure(error: crate::Error) -> ModelCycleFailure {
+        let stream = Box::pin(tokio_stream::iter(vec![Err(error)]));
+        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(4);
+        consume_model_cycle(stream, &event_tx, &CancellationToken::new())
+            .await
+            .unwrap_err()
+    }
 
     #[tokio::test]
     async fn provider_tool_names_are_normalized_when_received() {

--- a/server/src/run/model_retry.rs
+++ b/server/src/run/model_retry.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use axum::http::StatusCode;
+
 use super::ModelCycleFailure;
 
 pub(super) const MAX_MODEL_RETRIES: u32 = 8;
@@ -9,6 +11,21 @@ pub(super) const MODEL_RETRY_DELAY: Duration = Duration::from_secs(5);
 
 pub(super) fn should_retry(failure: &ModelCycleFailure, retries: u32) -> bool {
     failure.retryable && retries < MAX_MODEL_RETRIES
+}
+
+/// Provider responses a repeat cannot fix: the provider refused the request
+/// itself (bad key, unknown model, invalid body). 408 and 429 are the two 4xx
+/// statuses that ask for another attempt, so they stay transient like 5xx.
+pub(super) fn is_permanent_rejection(error: &crate::Error) -> bool {
+    matches!(
+        error,
+        crate::Error::ProviderStatus { status, .. }
+            if status.is_client_error()
+                && !matches!(
+                    *status,
+                    StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+                )
+    )
 }
 
 #[cfg(test)]
@@ -38,5 +55,29 @@ mod tests {
     #[test]
     fn terminal_failures_never_retry() {
         assert!(!should_retry(&failure(false), 0));
+    }
+
+    fn status_error(status: u16) -> crate::Error {
+        crate::Error::ProviderStatus {
+            status: StatusCode::from_u16(status).unwrap(),
+            message: format!("test {status}"),
+        }
+    }
+
+    #[test]
+    fn rejected_requests_are_permanent() {
+        for status in [400, 401, 403, 404, 422] {
+            assert!(is_permanent_rejection(&status_error(status)), "{status}");
+        }
+    }
+
+    #[test]
+    fn overload_timeouts_and_transport_failures_stay_transient() {
+        for status in [408, 429, 500, 502, 503, 529] {
+            assert!(!is_permanent_rejection(&status_error(status)), "{status}");
+        }
+        assert!(!is_permanent_rejection(&crate::Error::Provider(
+            "stream disconnected".into()
+        )));
     }
 }

--- a/server/tests/error_lifecycle.rs
+++ b/server/tests/error_lifecycle.rs
@@ -6,6 +6,7 @@ mod fixtures;
 
 use std::sync::Arc;
 
+use axum::http::StatusCode;
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use cursor_server::{
     cursor::prompting::{PromptAssets, PromptCompiler},
@@ -286,6 +287,85 @@ async fn provider_failure_keeps_the_initial_checkpoint_then_returns_structured_e
             MessageContent::Assistant { text, .. } if text.contains("Cursor server error")
         )
     }));
+}
+
+#[tokio::test]
+async fn rejected_provider_request_is_reported_after_one_attempt() {
+    let (_directory, store) = fixtures::temp_store().await;
+    let provider = fake_provider::FakeProvider::default();
+    provider.push_error(Error::ProviderStatus {
+        status: StatusCode::UNAUTHORIZED,
+        message: "OpenAI Chat 401 Unauthorized: invalid api key".into(),
+    });
+    // A retry would consume this response and finish the run successfully.
+    provider.push(vec![
+        ModelEvent::Start {
+            model_call_id: "retried".into(),
+        },
+        ModelEvent::TextStart,
+        ModelEvent::TextDelta("retried".into()),
+        ModelEvent::TextEnd,
+        ModelEvent::Done(FinishReason::Stop),
+    ]);
+    let assets = PromptAssets::load(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("prompt/cursor")
+            .as_path(),
+    )
+    .unwrap();
+    let registry = TransportRegistry::new(
+        store,
+        Arc::new(provider.clone()),
+        PromptCompiler::new(assets),
+    );
+    let handle = registry.get_or_create("failed-request").await.unwrap();
+    let mut output = handle.subscribe();
+    handle
+        .command(TransportCommand::Append {
+            seqno: 0,
+            message: Box::new(client_run()),
+        })
+        .await
+        .unwrap();
+
+    let mut append_seqno = 1;
+    let error_json = loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(10), output.recv())
+            .await
+            .unwrap()
+            .expect("RunSSE closed before EndStream");
+        let (flags, payload) = connect::decode_frames(&frame).unwrap().pop().unwrap();
+        if flags & connect::END_STREAM_FLAG != 0 {
+            break serde_json::from_slice::<serde_json::Value>(&payload).unwrap();
+        }
+        let server = pb::AgentServerMessage::decode(payload).unwrap();
+        if let Some(pb::agent_server_message::Message::KvServerMessage(kv)) = server.message {
+            handle
+                .command(TransportCommand::Append {
+                    seqno: append_seqno,
+                    message: Box::new(kv_ack(kv.id)),
+                })
+                .await
+                .unwrap();
+            append_seqno += 1;
+        }
+    };
+
+    assert_eq!(
+        provider.requests().len(),
+        1,
+        "a 401 must be reported after one attempt"
+    );
+    assert_eq!(error_json["error"]["code"], "unavailable");
+    let encoded = error_json["error"]["details"][0]["value"].as_str().unwrap();
+    let decoded = STANDARD_NO_PAD.decode(encoded).unwrap();
+    let decoded = ai::ErrorDetails::decode(decoded.as_slice()).unwrap();
+    let custom = decoded.details.unwrap();
+    assert!(
+        custom.detail.contains("401 Unauthorized"),
+        "{}",
+        custom.detail
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Re-targets #394 onto the retry layer that replaced `provider/retry.rs`.

## Problem

`d83e14a` removed `send_with_retry`, which is where #394 lived, but the
bug survived the move and got worse. On `main` today:

1. `provider/attempt.rs::send_once` turns every non-2xx into
   `Error::Provider("{label} {status}: body")` — the status survives only
   as text.
2. `run/event.rs` maps that to `RunFailure::Provider`.
3. `run/model_cycle.rs::failure` marks every `Provider`/`Protocol` failure
   `retryable`.
4. `run/model_retry.rs` allows `MAX_MODEL_RETRIES = 8` with a 5 s delay, and
   `run/engine.rs` re-sends under a fresh `…:retry-N` call id each time.

So a request the provider has *rejected* is now sent **9 times over ~40 s**:

| user mistake | status | today |
|---|---|---|
| mistyped API key | 401 | 9 requests, ~40 s, 9 `llm_calls` rows |
| model id the endpoint does not serve | 404 | same |
| body the endpoint rejects | 400 / 422 | same |

During first-time BYOK setup — exactly when these statuses happen — the app
looks hung for 40 seconds and then reports the error it already had at t=0.

## Fix

Carry the status structurally and classify it in the retry policy:

- **`error.rs`** — new `Error::ProviderStatus { status: StatusCode, message }`.
  Display text is unchanged (`provider error: {label} {status}: {body}`),
  `IntoResponse` still answers 502 for it.
- **`provider/attempt.rs`** — `send_once` returns `ProviderStatus` instead of
  flattening the status into a string.
- **`run/model_retry.rs`** — `is_permanent_rejection`: a `ProviderStatus`
  with a 4xx other than **408** and **429** cannot succeed on repeat.
- **`run/model_cycle.rs`** — such an error builds a `terminal_failure`
  (the helper already used for `Length` stops) instead of a retryable one.
  `should_retry` and the engine loop are untouched.
- **`run/event.rs`, `provider/recorder.rs`** — the new variant maps exactly
  where `Error::Provider` maps today (same message, same `"provider"` kind
  on the `llm_calls` row).

Unchanged on purpose: 408, 429, every 5xx, transport failures
(`Error::Http`), mid-stream errors, and plugin-model errors (plugin workers
report text only, so they stay retryable as before).

## Verification

`main` itself does not compile the `cursor-server` lib-test target until
#408 lands, so every run below is on this branch merged with #408 — the
tree `main` becomes once both merge. The PR branch carries only this change.

Fail-before was produced by neutralising the rule (`if false && …` in
`is_permanent_rejection`), i.e. today's "everything retries" behaviour:

```
$ cargo test -p cursor-server --lib -- run::model_retry run::model_cycle
run::model_retry::tests::rejected_requests_are_permanent ............... FAILED
run::model_cycle::tests::rejected_provider_requests_are_terminal ....... FAILED
    assertion failed: !failure.retryable
run::model_retry::tests::overload_timeouts_and_transport_failures_stay_transient  ok
run::model_cycle::tests::overloaded_provider_requests_stay_retryable ... ok

$ cargo test -p cursor-server --test error_lifecycle rejected_provider
rejected_provider_request_is_reported_after_one_attempt ................ FAILED
    assertion `left == right` failed: a 401 must be reported after one attempt
      left: 2
     right: 1
    (the retry consumed the sentinel success response and the run went green)
```

With the rule in place:

```
$ cargo fmt --all -- --check                               (clean, exit 0)
$ cargo clippy --workspace --all-targets -- -D warnings    (clean, exit 0)
$ cargo test --workspace --no-fail-fast
cursor-server (lib) ......... 89 passed   (incl. the 4 new + updated attempt test)
error_lifecycle ............. 8 passed    (incl. rejected_provider_request_is_reported_after_one_attempt)
every other target .......... passed
local_rules_context ......... 1 FAILED    <- pre-existing, fixed by #390, not touched here
```

The 408 / 429 / 5xx / transport tests pass **both** before and after, so the
retry path itself is provably unchanged — this only decides *which* failures
are worth repeating.

Predecessor: #394 (closed in favour of this one).
