### PR TITLE
fix(provider): scope OpenAI Responses text reconciliation to one output item

### DIFF
--- a/server/src/provider/openai_responses.rs
+++ b/server/src/provider/openai_responses.rs
@@ -113,6 +113,7 @@ impl Provider for OpenAiResponsesProvider {
             futures_util::pin_mut!(source);
             let mut text_open = false;
             let mut text = String::new();
+            let mut text_index = None;
             let mut thinking_open = false;
             let mut tools = std::collections::BTreeMap::<usize, ResponseToolState>::new();
             let mut reasoning_items = Vec::new();
@@ -134,6 +135,7 @@ impl Provider for OpenAiResponsesProvider {
                 let kind = value.get("type").and_then(Value::as_str).unwrap_or(&event.event);
                 match kind {
                     "response.output_text.delta" => {
+                        enter_response_text_item(&value, &mut text_index, &mut text);
                         if thinking_open { thinking_open = false; yield ModelEvent::ThinkingEnd; }
                         if !text_open { text_open = true; yield ModelEvent::TextStart; }
                         if let Some(delta) = value.get("delta").and_then(Value::as_str) {
@@ -142,6 +144,7 @@ impl Provider for OpenAiResponsesProvider {
                         }
                     }
                     "response.output_text.done" => {
+                        enter_response_text_item(&value, &mut text_index, &mut text);
                         if let Some(final_text) = value.get("text").and_then(Value::as_str) {
                             for event in reconcile_response_text(&mut text_open, &mut text, final_text) { yield event; }
                         }
@@ -170,6 +173,7 @@ impl Provider for OpenAiResponsesProvider {
                             }
                             Some("message") => {
                                 saw_completed_item = true;
+                                enter_response_text_item(&value, &mut text_index, &mut text);
                                 if let Some(final_text) = response_item_text(item) {
                                     for event in reconcile_response_text(&mut text_open, &mut text, &final_text) { yield event; }
                                 }
@@ -282,6 +286,20 @@ fn response_item_text(item: &Value) -> Option<String> {
         .filter_map(|part| part.get("text").and_then(Value::as_str))
         .collect::<String>();
     Some(text)
+}
+
+/// Scopes the streamed text accumulator to a single output item.
+///
+/// `response.output_text.done` and `response.output_item.done` report the final
+/// text of one item, so reconciliation is only meaningful against the deltas of
+/// that same item. Events without an `output_index` keep the current scope.
+fn enter_response_text_item(value: &Value, current: &mut Option<u64>, streamed: &mut String) {
+    let Some(index) = value.get("output_index").and_then(Value::as_u64) else {
+        return;
+    };
+    if current.replace(index) != Some(index) {
+        streamed.clear();
+    }
 }
 
 fn reconcile_response_text(
@@ -580,5 +598,66 @@ mod tests {
                 "encrypted_content": "opaque"
             })]
         );
+    }
+
+    #[test]
+    fn a_later_output_item_reconciles_against_its_own_text() {
+        let mut open = false;
+        let mut streamed = String::new();
+        let mut index = None;
+
+        enter_response_text_item(&json!({"output_index": 0}), &mut index, &mut streamed);
+        assert_eq!(
+            reconcile_response_text(&mut open, &mut streamed, "checking the file"),
+            vec![
+                ModelEvent::TextStart,
+                ModelEvent::TextDelta("checking the file".into())
+            ]
+        );
+        open = false;
+
+        enter_response_text_item(&json!({"output_index": 2}), &mut index, &mut streamed);
+        assert_eq!(
+            reconcile_response_text(&mut open, &mut streamed, "the file looks fine"),
+            vec![
+                ModelEvent::TextStart,
+                ModelEvent::TextDelta("the file looks fine".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn a_later_output_item_still_repairs_a_truncated_delta_stream() {
+        let mut open = true;
+        let mut streamed = String::new();
+        let mut index = None;
+
+        enter_response_text_item(&json!({"output_index": 0}), &mut index, &mut streamed);
+        streamed.push_str("checking the file");
+
+        enter_response_text_item(&json!({"output_index": 3}), &mut index, &mut streamed);
+        streamed.push_str("the file ");
+        assert_eq!(
+            reconcile_response_text(&mut open, &mut streamed, "the file looks fine"),
+            vec![ModelEvent::TextDelta("looks fine".into())]
+        );
+    }
+
+    #[test]
+    fn repeated_reports_for_one_output_item_do_not_replay_its_text() {
+        let mut open = false;
+        let mut streamed = String::new();
+        let mut index = None;
+        let event = json!({"output_index": 0});
+
+        enter_response_text_item(&event, &mut index, &mut streamed);
+        assert_eq!(
+            reconcile_response_text(&mut open, &mut streamed, "done"),
+            vec![ModelEvent::TextStart, ModelEvent::TextDelta("done".into())]
+        );
+        open = false;
+
+        enter_response_text_item(&event, &mut index, &mut streamed);
+        assert!(reconcile_response_text(&mut open, &mut streamed, "done").is_empty());
     }
 }


### PR DESCRIPTION
## The bug

`reconcile_response_text` repairs a stream whose `output_text` deltas are incomplete: when `response.output_text.done` or `response.output_item.done` reports a final text longer than what was streamed, the missing suffix is emitted as one more `TextDelta`.

Its baseline is wrong. `text` accumulated **every delta of the whole response**, but `final_text` only ever describes **one output item**:

```rust
let mut text = String::new();          // per response
...
"response.output_text.done" => {
    if let Some(final_text) = value.get("text").and_then(Value::as_str) {
        for event in reconcile_response_text(&mut text_open, &mut text, final_text) { yield event; }
    }
```

```rust
if final_text.starts_with(streamed.as_str()) && final_text.len() > streamed.len() {
```

A Responses stream routinely carries more than one text-bearing item — the model writes a sentence, calls a tool, then writes more, and each block is its own `message` item. From the **second** item onward, `streamed` holds the concatenation of all previous items, `starts_with` is false, and the repair silently stops happening.

## Failure mode

An assistant turn that ends in blank text.

When an upstream relay reports text only through terminal events and never sends `response.output_text.delta` — a common shape for OpenAI-compatible gateways — the reconciler *is* the only thing emitting text. Item 0 is emitted correctly, and every later item is dropped entirely, because the accumulator it is checked against is no longer empty:

| event | `streamed` before | `final_text` | emitted |
| --- | --- | --- | --- |
| `output_item.done` (message, `output_index` 0) | `""` | `"checking the file"` | `TextStart`, `TextDelta("checking the file")` |
| `output_item.done` (function_call, 1) | — | — | tool call, fine |
| `output_item.done` (message, `output_index` 2) | `"checking the file"` | `"the file looks fine"` | **nothing** |

The same wrong baseline also disables the partial-delta repair for any later item, so a truncated delta stream loses its tail instead of being completed.

## The fix

Track the `output_index` the accumulator belongs to, and clear it when the provider moves to a different item, so each item reconciles against its own deltas. This mirrors how tool state is already keyed by `output_index` in this file.

Two properties are preserved deliberately:

- Events that omit `output_index` keep the current scope, so lenient relays behave exactly as before — nothing new is made `required_u64`.
- Repeated reports for one item (`response.output_text.done` followed by `response.output_item.done`) resolve to the same index, so they still share a baseline and cannot replay the same text twice.

## Verification

`cargo +1.95 test --package cursor-server --lib provider::openai_responses`

Before (fix neutered in place, tests kept):

```
---- a_later_output_item_reconciles_against_its_own_text stdout ----
assertion `left == right` failed
  left: []
 right: [TextStart, TextDelta("the file looks fine")]

---- a_later_output_item_still_repairs_a_truncated_delta_stream stdout ----
assertion `left == right` failed
  left: []
 right: [TextDelta("looks fine")]

test result: FAILED. 2 passed; 2 failed
```

After:

```
test provider::openai_responses::tests::repeated_reports_for_one_output_item_do_not_replay_its_text ... ok
test provider::openai_responses::tests::a_later_output_item_reconciles_against_its_own_text ... ok
test provider::openai_responses::tests::a_later_output_item_still_repairs_a_truncated_delta_stream ... ok
test provider::openai_responses::tests::reasoning_replay_projects_response_items_to_valid_input_items ... ok

test result: ok. 4 passed; 0 failed
```

Gates (`make check`, Rust half):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean on CI's stable; see note below
- `cargo test --workspace --all-targets` — passes, apart from a pre-existing local flake in `cursor_trace_queue::trace_producers_do_not_wait_for_sqlite_and_artifacts_stay_ordered` (a 10 ms-poll timing assertion, 1 failure in 5 runs on this Windows box, unrelated to this change; green in CI on `main`).

Toolchain note: this machine's `stable` is broken, so the gates were run with `+1.95`. Clippy 1.95 reports one `collapsible_match` error in `server/src/cursor/compile/model.rs:109` on unmodified `main` — that is a 1.95-only false positive (its own suggestion, `"fast" if parse_bool(parameter)? =>`, does not compile, since `?` is not allowed in a match guard) and CI's 1.98.1 does not emit it, so `main` is green. Clippy here was therefore run with `-A clippy::collapsible_match`; nothing in this diff is affected either way.
