### PR TITLE
fix(store): keep an unreadable proxy row from bricking every request

### DIFF
--- a/server/src/store/settings.rs
+++ b/server/src/store/settings.rs
@@ -160,6 +160,22 @@ pub(crate) struct ProxySettingsSecret {
     pub password: String,
 }
 
+/// Reads the persisted outbound proxy row, falling back to "no proxy" when it
+/// no longer parses.
+///
+/// `mode` is a closed enum whose stored wire value has already changed once, so
+/// a row written by an older build can be unreadable by this one. Propagating
+/// that error would be unrecoverable rather than merely noisy: every outbound
+/// client is built from this value, and `set_proxy_settings` reads the row
+/// before it writes, so the settings page could neither load nor replace the
+/// row that broke it.
+fn read_proxy_settings(value: &str) -> ProxySettingsSecret {
+    serde_json::from_str(value).unwrap_or_else(|error| {
+        tracing::warn!(%error, "ignoring unreadable outbound proxy settings");
+        ProxySettingsSecret::default()
+    })
+}
+
 impl Store {
     pub(crate) async fn cursor_takeover_enabled(&self) -> Result<bool> {
         let value = sqlx::query_scalar::<_, String>(
@@ -218,9 +234,9 @@ impl Store {
         .bind(PROXY_SETTINGS_KEY)
         .fetch_optional(&self.pool)
         .await?;
-        value
-            .map(|value| serde_json::from_str(&value).map_err(Into::into))
-            .unwrap_or_else(|| Ok(ProxySettingsSecret::default()))
+        Ok(value
+            .as_deref()
+            .map_or_else(ProxySettingsSecret::default, read_proxy_settings))
     }
 
     pub async fn proxy_settings(&self) -> Result<ProxySettings> {
@@ -415,9 +431,15 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::{
-        CommitPromptLocale, CommitSettings, ProxyMode, DEFAULT_COMMIT_PROMPT_EN_US,
-        DEFAULT_COMMIT_PROMPT_ZH_CN,
+        read_proxy_settings, CommitPromptLocale, CommitSettings, ProxyMode, ProxySettingsInput,
+        ProxySettingsSecret, Store, DEFAULT_COMMIT_PROMPT_EN_US, DEFAULT_COMMIT_PROMPT_ZH_CN,
+        PROXY_SETTINGS_KEY,
     };
+
+    /// The `outbound_proxy` row exactly as builds before the `system` -> `default`
+    /// rename wrote it.
+    const LEGACY_PROXY_ROW: &str =
+        r#"{"mode":"system","address":"","auth_enabled":false,"username":"","password":""}"#;
 
     #[test]
     fn default_commit_prompt_follows_its_saved_locale() {
@@ -457,5 +479,50 @@ mod tests {
             ProxyMode::Default
         );
         assert!(serde_json::from_str::<ProxyMode>("\"system\"").is_err());
+    }
+
+    #[test]
+    fn an_unreadable_proxy_row_reads_as_no_proxy() {
+        assert!(serde_json::from_str::<ProxySettingsSecret>(LEGACY_PROXY_ROW).is_err());
+
+        let settings = read_proxy_settings(LEGACY_PROXY_ROW);
+        assert_eq!(settings.mode, ProxyMode::Default);
+        assert!(settings.address.is_empty());
+        assert!(!settings.auth_enabled);
+    }
+
+    #[tokio::test]
+    async fn a_proxy_row_from_an_older_build_stays_replaceable() {
+        let directory = tempfile::tempdir().unwrap();
+        let url = format!("sqlite://{}", directory.path().join("test.db").display());
+        let store = Store::connect(&url).await.unwrap();
+        sqlx::query(
+            "INSERT INTO service_settings(setting_key, value_json, updated_at_ms) VALUES (?, ?, 0)",
+        )
+        .bind(PROXY_SETTINGS_KEY)
+        .bind(LEGACY_PROXY_ROW)
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+        // Reading must not fail: every outbound client is built from this value.
+        assert_eq!(
+            store.proxy_settings().await.unwrap().mode,
+            ProxyMode::Default
+        );
+
+        // And the settings page must be able to overwrite the row that broke it.
+        let saved = store
+            .set_proxy_settings(ProxySettingsInput {
+                mode: ProxyMode::Custom,
+                address: "http://127.0.0.1:7890".into(),
+                auth_enabled: false,
+                username: String::new(),
+                password: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(saved.mode, ProxyMode::Custom);
+        assert_eq!(saved.address, "http://127.0.0.1:7890");
     }
 }


### PR DESCRIPTION
## The bug

`8942287` ("refactor(proxy): change proxy mode from `system` to `default`") renamed the enum variant:

```rust
 pub enum ProxyMode {
     #[default]
-    System,
+    Default,
     Custom,
 }
```

`ProxyMode` is `#[serde(rename_all = "snake_case")]`, so the **persisted** wire value changed from `"system"` to `"default"`. Nothing migrates the existing row, and there is no alias, so any install that ever pressed Save on the proxy card before this build holds a `service_settings` row that this build cannot read:

```
Error("unknown variant `system`, expected `default` or `custom`", line: 1, column: 16)
```

`ProxyMode::System` has existed since the initial schema commit, so this is every upgrading install with saved proxy settings — including those that only ever left it on the default.

## Why it is worse than a bad proxy

`proxy_settings_secret` propagated the error, and it is the **first statement of every outbound client factory** (`network.rs:97`, `:112`), which `provider_client` / `cursor_client` / `default_client` all go through. On upgrade the read failure takes out model calls, plugin installs (`plugin/installation.rs:65`), search (`search/fetch.rs:127`, `search/search_provider.rs:98`) and the Cursor upstream proxy (`api/cursor/proxy.rs`).

And it is unrecoverable from the UI, which is the part that made this worth a fix rather than a note:

- `proxy_settings()` reads the same row, so the settings page cannot render the proxy card.
- `set_proxy_settings()` reads the existing row **before** it writes (it needs the old password when `password: None`), so the Save that would replace the bad value fails on the bad value.

`Error::Json` maps to a 4xx, so the user sees a request error on a settings page and has no way forward short of editing SQLite by hand.

## The fix

Read the row through a fallback that logs and returns the default:

```rust
fn read_proxy_settings(value: &str) -> ProxySettingsSecret {
    serde_json::from_str(value).unwrap_or_else(|error| {
        tracing::warn!(%error, "ignoring unreadable outbound proxy settings");
        ProxySettingsSecret::default()
    })
}
```

The rows this actually affects are the ones whose mode meant "no outbound proxy" — which is precisely what `ProxyMode::Default` is — so nothing is silently changed for them. A genuinely corrupt row costs the user a re-entered address instead of a dead install, and the warning says why.

**Deliberately not `#[serde(alias = "system")]`.** `8942287` added `default_proxy_mode_uses_the_default_wire_value`, which asserts `serde_json::from_str::<ProxyMode>("\"system\"").is_err()`. This keeps that assertion true. If you would rather the old value keep its meaning exactly, the alias is a one-line change and I am happy to switch — that is your call on intent, not mine.

## Verification

`cargo +1.95 test --package cursor-server --lib store::settings`

Before (fallback replaced with `.unwrap()`, tests kept):

```
---- store::settings::tests::an_unreadable_proxy_row_reads_as_no_proxy stdout ----
called `Result::unwrap()` on an `Err` value:
  Error("unknown variant `system`, expected `default` or `custom`", line: 1, column: 16)

---- store::settings::tests::a_proxy_row_from_an_older_build_stays_replaceable stdout ----
called `Result::unwrap()` on an `Err` value:
  Error("unknown variant `system`, expected `default` or `custom`", line: 1, column: 16)

test result: FAILED. 3 passed; 2 failed
```

After:

```
test store::settings::tests::an_unreadable_proxy_row_reads_as_no_proxy ... ok
test store::settings::tests::a_proxy_row_from_an_older_build_stays_replaceable ... ok
test store::settings::tests::default_proxy_mode_uses_the_default_wire_value ... ok
test store::settings::tests::default_commit_prompt_follows_its_saved_locale ... ok
test store::settings::tests::custom_commit_prompt_does_not_change_with_locale ... ok

test result: ok. 5 passed; 0 failed
```

The second test is the one that matters: it writes the pre-rename row into a real store, then asserts both that `proxy_settings()` still reads and that `set_proxy_settings()` can overwrite it — i.e. that the settings page is reachable again.

Gates (`make check`, Rust half):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean on CI's stable; see note
- `cargo test --workspace --all-targets` — all suites green

Toolchain note: this machine's `stable` is broken, so the gates ran with `+1.95`. Clippy 1.95 reports a `collapsible_match` error at `server/src/cursor/compile/model.rs:109` on unmodified `main`; that is a 1.95-only false positive (its own suggestion, `"fast" if parse_bool(parameter)? =>`, does not compile — `?` is not allowed in a match guard) and CI's 1.98.1 does not emit it, so `main` is green. Clippy here therefore ran with `-A clippy::collapsible_match`; this diff is unaffected either way.

## Related

This is plausibly behind #404 ("changing network environment ... BYOK link drops, custom model cannot be selected, connectivity test also errors"), where the reporter's trigger is toggling proxy software — but I have not reproduced their setup, so treat that as a lead rather than a claim.
