### PR TITLE
fix(provider): stop Anthropic refusals from executing their tool blocks

### DIFF
--- a/server/src/provider/anthropic.rs
+++ b/server/src/provider/anthropic.rs
@@ -119,6 +119,7 @@ impl Provider for AnthropicProvider {
             let mut thinking_signatures = std::collections::HashMap::<usize, String>::new();
             let mut thinking_blocks = Vec::new();
             let mut finish = None;
+            let mut refused = false;
             let mut saw_tool = false;
             let mut terminal = false;
             let mut final_usage = None::<Usage>;
@@ -208,7 +209,9 @@ impl Provider for AnthropicProvider {
                         if let Some(usage) = value.get("usage") {
                             merge_usage(final_usage.get_or_insert_default(), anthropic_usage(usage));
                         }
-                        finish = match value.pointer("/delta/stop_reason").and_then(Value::as_str) {
+                        let stop_reason = value.pointer("/delta/stop_reason").and_then(Value::as_str);
+                        refused |= stop_reason == Some("refusal");
+                        finish = match stop_reason {
                             Some("tool_use") => Some(FinishReason::ToolUse),
                             Some("max_tokens" | "model_context_window_exceeded") => Some(FinishReason::Length),
                             Some("end_turn" | "stop_sequence" | "pause_turn" | "refusal") => Some(FinishReason::Stop),
@@ -234,13 +237,7 @@ impl Provider for AnthropicProvider {
                         if let Some(usage) = final_usage {
                             yield ModelEvent::Usage(usage);
                         }
-                        let finish = match finish {
-                            Some(FinishReason::Length) => FinishReason::Length,
-                            _ if saw_tool => FinishReason::ToolUse,
-                            Some(finish) => finish,
-                            None => FinishReason::Stop,
-                        };
-                        yield ModelEvent::Done(finish);
+                        yield ModelEvent::Done(collapse_anthropic_finish(finish, saw_tool, refused));
                     }
                     _ => {}
                 }
@@ -259,13 +256,7 @@ impl Provider for AnthropicProvider {
                 }
                 if let Some(usage) = final_usage { yield ModelEvent::Usage(usage); }
                 terminal = true;
-                let finish = match finish {
-                    Some(FinishReason::Length) => FinishReason::Length,
-                    _ if saw_tool => FinishReason::ToolUse,
-                    Some(finish) => finish,
-                    None => FinishReason::Stop,
-                };
-                yield ModelEvent::Done(finish);
+                yield ModelEvent::Done(collapse_anthropic_finish(finish, saw_tool, refused));
             }
             if !terminal {
                 Err(Error::Provider("Anthropic stream ended without message_stop".into()))?;
@@ -502,9 +493,81 @@ fn anthropic_usage(value: &Value) -> Usage {
     }
 }
 
+/// Collapses the reported stop reason against the blocks actually streamed.
+///
+/// Observed tool calls outrank an ordinary stop, because Anthropic reports
+/// `end_turn` alongside `tool_use` blocks and those calls are meant to run. A
+/// refusal is the exception: the model declined the turn, so any tool blocks it
+/// streamed alongside the refusal must not be executed.
+fn collapse_anthropic_finish(
+    finish: Option<FinishReason>,
+    saw_tool: bool,
+    refused: bool,
+) -> FinishReason {
+    match finish {
+        Some(FinishReason::Length) => FinishReason::Length,
+        _ if refused => FinishReason::Stop,
+        _ if saw_tool => FinishReason::ToolUse,
+        Some(finish) => finish,
+        None => FinishReason::Stop,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_refusal_never_executes_the_tool_blocks_it_streamed() {
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::Stop), true, true),
+            FinishReason::Stop
+        );
+        assert_eq!(
+            collapse_anthropic_finish(None, true, true),
+            FinishReason::Stop
+        );
+    }
+
+    #[test]
+    fn observed_tool_blocks_still_outrank_an_ordinary_stop() {
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::Stop), true, false),
+            FinishReason::ToolUse
+        );
+        assert_eq!(
+            collapse_anthropic_finish(None, true, false),
+            FinishReason::ToolUse
+        );
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::ToolUse), true, false),
+            FinishReason::ToolUse
+        );
+    }
+
+    #[test]
+    fn a_truncated_response_stays_truncated() {
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::Length), true, false),
+            FinishReason::Length
+        );
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::Length), true, true),
+            FinishReason::Length
+        );
+    }
+
+    #[test]
+    fn a_stop_without_tool_blocks_is_unchanged() {
+        assert_eq!(
+            collapse_anthropic_finish(Some(FinishReason::Stop), false, false),
+            FinishReason::Stop
+        );
+        assert_eq!(
+            collapse_anthropic_finish(None, false, false),
+            FinishReason::Stop
+        );
+    }
 
     #[test]
     fn cached_tokens_are_included_once_in_anthropic_context_input() {


### PR DESCRIPTION
## The bug

`message_delta` already classifies a refusal correctly:

```rust
Some("end_turn" | "stop_sequence" | "pause_turn" | "refusal") => Some(FinishReason::Stop),
```

…and then the collapse in `message_stop` throws that classification away:

```rust
let finish = match finish {
    Some(FinishReason::Length) => FinishReason::Length,
    _ if saw_tool => FinishReason::ToolUse,   // <- ahead of Some(finish)
    Some(finish) => finish,
    None => FinishReason::Stop,
};
```

The `saw_tool` guard is ordered ahead of `Some(finish)`, so a response with `stop_reason: "refusal"` that also streamed a `tool_use` block is reported as `ToolUse`. In `model_cycle`:

```rust
let has_tool_calls = !calls.is_empty();
if matches!(finish_reason, FinishReason::ToolUse) != has_tool_calls {
    return Err(failure(RunFailure::Protocol("finish reason and tool calls disagree".into()), ...));
}
```

…the finish reason now agrees with the observed calls, the guard passes, and **the tool calls from a refused turn are executed**. The `"refusal"` arm above is effectively dead whenever a tool block was streamed.

This is the same mistake `aa47152` ("fix(provider): preserve content-filtered tool call rejection") removed from the OpenAI chat adapter, where `_ if has_tools` outranked `content_filter`.

## The fix

Track the refusal alongside the finish reason and give it precedence over observed tool calls, so the turn fails as a disagreement rather than executing — the same outcome `aa47152` established for `content_filter`.

Ordinary stops keep yielding to observed tool calls, because Anthropic reports `end_turn` alongside legitimate `tool_use` blocks; only the refusal is carved out. `Length` keeps its existing top precedence.

The collapse was duplicated verbatim in the `message_stop` path and the non-terminal fallback path, and only one of them would realistically have been updated by hand. Both now call one function, so the precedence cannot drift apart again — which is also what makes it unit-testable, matching how `map_finish` is tested in `openai_chat.rs`.

## Verification

`cargo +1.95 test --package cursor-server --lib provider::anthropic`

Before (the `_ if refused` arm removed, tests kept):

```
---- provider::anthropic::tests::a_refusal_never_executes_the_tool_blocks_it_streamed stdout ----
assertion `left == right` failed
  left: ToolUse
 right: Stop

test result: FAILED. 5 passed; 1 failed
```

After:

```
test provider::anthropic::tests::a_refusal_never_executes_the_tool_blocks_it_streamed ... ok
test provider::anthropic::tests::a_stop_without_tool_blocks_is_unchanged ... ok
test provider::anthropic::tests::observed_tool_blocks_still_outrank_an_ordinary_stop ... ok
test provider::anthropic::tests::a_truncated_response_stays_truncated ... ok
test provider::anthropic::tests::cached_tokens_are_included_once_in_anthropic_context_input ... ok
test provider::anthropic::tests::streamed_anthropic_usage_includes_cached_input_in_total ... ok

test result: ok. 6 passed; 0 failed
```

The three tests beyond the fix pin the precedence that must **not** change: observed tool blocks still beat an ordinary stop, a truncated response stays truncated, and a plain stop without tool blocks is untouched.

Gates (`make check`, Rust half):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean on CI's stable; see note
- `cargo test --workspace --all-targets` — all suites green

Toolchain note: this machine's `stable` is broken, so the gates ran with `+1.95`. Clippy 1.95 reports a `collapsible_match` error at `server/src/cursor/compile/model.rs:109` on unmodified `main`; that is a 1.95-only false positive (its own suggestion, `"fast" if parse_bool(parameter)? =>`, does not compile — `?` is not allowed in a match guard) and CI's 1.98.1 does not emit it, so `main` is green. Clippy here therefore ran with `-A clippy::collapsible_match`; this diff is unaffected either way.
