### PR TITLE
fix(tools): keep a message interrupt from muting the Tasks it spares

### DIFF
--- a/server/src/cursor/tools/runtime.rs
+++ b/server/src/cursor/tools/runtime.rs
@@ -310,10 +310,10 @@ impl CursorToolRuntime {
             let mut abort_ids = Vec::new();
             let mut interrupted_ids = Vec::new();
             entries.retain(|id, entry| {
-                interrupted_ids.push(*id);
                 let keep_running = entry.call.name.eq_ignore_ascii_case("Task");
                 if !keep_running {
                     abort_ids.push(*id);
+                    interrupted_ids.push(*id);
                 }
                 keep_running
             });
@@ -364,4 +364,61 @@ pub(crate) fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_call(call_id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            index: 0,
+            call_id: call_id.into(),
+            model_call_id: "model-call".into(),
+            name: name.into(),
+            arguments_text: "{}".into(),
+            arguments: serde_json::json!({}),
+            argument_error: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_message_interrupt_does_not_mute_the_tasks_it_keeps_running() {
+        let runtime = CursorToolRuntime::default();
+        let context = ExecContext::default();
+        let task = runtime
+            .reserve_exec(&tool_call("call-task", "Task"), &context)
+            .await
+            .unwrap();
+        let shell = runtime
+            .reserve_exec(&tool_call("call-shell", "Shell"), &context)
+            .await
+            .unwrap();
+
+        assert_eq!(runtime.interrupt_for_message().await, vec![shell]);
+
+        // The Task was deliberately left running, so its events must still land.
+        assert!(!runtime.is_interrupted(task).await);
+        assert!(runtime.append_stdout(task, "still running").await);
+        assert!(runtime.is_interrupted(shell).await);
+    }
+
+    #[tokio::test]
+    async fn a_message_interrupt_still_mutes_and_aborts_everything_else() {
+        let runtime = CursorToolRuntime::default();
+        let context = ExecContext::default();
+        let read = runtime
+            .reserve_exec(&tool_call("call-read", "Read"), &context)
+            .await
+            .unwrap();
+        let interaction = runtime
+            .reserve_interaction(&tool_call("call-ask", "AskQuestion"))
+            .await
+            .unwrap();
+
+        assert_eq!(runtime.interrupt_for_message().await, vec![read]);
+
+        assert!(runtime.is_interrupted(read).await);
+        assert!(runtime.is_interrupted(interaction).await);
+    }
 }


### PR DESCRIPTION
## The bug

`interrupt_for_message` runs when the user sends a message mid-turn. It deliberately spares background `Task` execs — they are kept in the map and no abort is emitted for them — while aborting everything else:

```rust
entries.retain(|id, entry| {
    interrupted_ids.push(*id);                                    // <- every id, unconditionally
    let keep_running = entry.call.name.eq_ignore_ascii_case("Task");
    if !keep_running {
        abort_ids.push(*id);
    }
    keep_running
});
```

The push happens **before** the `keep_running` decision, so the spared Tasks land in `interrupted_ids` alongside the aborted ones and are added to `self.interrupted`. Nothing ever removes an individual id from that set (`interrupted_rounds`, its neighbour in the conversation layer, *is* pruned per round; this one is not — only the wholesale `drain_running` clears it).

That set gates the client event path:

```rust
if pending.is_interrupted(message.id).await {
    if message.message.as_ref().is_some_and(is_terminal) {
        pending.discard_exec(message.id).await;
    }
    return Ok(ClientExecEvent::Pending);
}
```

## Failure mode

The Task keeps running on the client — correctly, no `abort` is emitted for it — and the server then:

1. drops every stdout/stderr delta it sends (`ClientExecEvent::Pending`), and
2. **discards the exec outright** when its terminal result arrives.

So the result never becomes a `ToolCompletion`, and the tool round goes on waiting for a completion that can no longer arrive. The `keep_running` branch was dead intent: sparing the Task from the abort only changed *how* it dies.

## The fix

Mark an exec interrupted only when it is also aborted — one moved line. Interaction ids are unaffected: they are cleared wholesale a few lines below and are still all marked, which the second test pins.

## Verification

`cargo +1.95 test --package cursor-server --lib cursor::tools::runtime`

Before (`interrupted_ids.push(*id)` moved back above the decision, tests kept):

```
---- a_message_interrupt_does_not_mute_the_tasks_it_keeps_running stdout ----
assertion failed: !runtime.is_interrupted(task).await

test result: FAILED. 1 passed; 1 failed
```

After:

```
test cursor::tools::runtime::tests::a_message_interrupt_does_not_mute_the_tasks_it_keeps_running ... ok
test cursor::tools::runtime::tests::a_message_interrupt_still_mutes_and_aborts_everything_else ... ok

test result: ok. 2 passed; 0 failed
```

The second test is the guard on the other side: a non-Task exec is still aborted *and* muted, and a pending interaction is still muted.

Gates (`make check`, Rust half):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean on CI's stable; see note
- `cargo test --workspace --all-targets` — all suites green

Toolchain note: this machine's `stable` is broken, so the gates ran with `+1.95`. Clippy 1.95 reports a `collapsible_match` error at `server/src/cursor/compile/model.rs:109` on unmodified `main`; that is a 1.95-only false positive (its own suggestion, `"fast" if parse_bool(parameter)? =>`, does not compile — `?` is not allowed in a match guard) and CI's 1.98.1 does not emit it, so `main` is green. Clippy here therefore ran with `-A clippy::collapsible_match`; this diff is unaffected either way.

## Related

This is the shape reported in #340 (Multitask: the subtask stops when it completes and the parent never continues), but I have not reproduced that report end to end, so treat it as a lead rather than a claim.
