### PR TITLE
fix: accept common tool parameter aliases

### DIFF
--- a/server/src/cursor/tools/codec/query.rs
+++ b/server/src/cursor/tools/codec/query.rs
@@ -12,6 +12,18 @@ pub fn tool_query(id: u32, call: &ToolCall) -> Result<pb::AgentServerMessage> {
             .map(str::to_string)
             .ok_or_else(|| Error::Protocol(format!("{} is missing {name}", call.name)))
     };
+    // Claude 系模型常按 Claude Code 习惯输出别名参数(如 query),逐个回退兼容。
+    let string_aliased = |names: &[&str]| -> Result<String> {
+        for name in names {
+            if let Some(value) = call.arguments.get(name).and_then(Value::as_str) {
+                return Ok(value.to_string());
+            }
+        }
+        Err(Error::Protocol(format!(
+            "{} is missing {}",
+            call.name, names[0]
+        )))
+    };
     let optional_string = |name: &str| {
         call.arguments
             .get(name)
@@ -80,7 +92,7 @@ pub fn tool_query(id: u32, call: &ToolCall) -> Result<pb::AgentServerMessage> {
         }
         "websearch" => Query::WebSearchRequestQuery(pb::WebSearchRequestQuery {
             args: Some(pb::WebSearchArgs {
-                search_term: string("search_term")?,
+                search_term: string_aliased(&["search_term", "query"])?,
                 tool_call_id: call.call_id.clone(),
             }),
         }),
@@ -213,4 +225,38 @@ fn normalized(value: &str) -> String {
         .filter(|character| character.is_ascii_alphanumeric())
         .flat_map(char::to_lowercase)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::tool_query;
+    use crate::cursor::protocol::proto::agent::v1 as pb;
+    use crate::model::ToolCall;
+
+    #[test]
+    fn web_search_accepts_query_as_search_term_alias() {
+        // Claude 系模型常按 Claude Code 习惯发送 query 而非 search_term,
+        // 交互查询编码必须接受别名,而不是报 `WebSearch is missing search_term`。
+        let call = ToolCall {
+            index: 0,
+            call_id: "call-1".into(),
+            model_call_id: "model-1".into(),
+            name: "WebSearch".into(),
+            arguments_text: String::new(),
+            arguments: json!({ "query": "lmarena leaderboard" }),
+            argument_error: None,
+        };
+        let message = tool_query(1, &call).unwrap();
+        let Some(pb::agent_server_message::Message::InteractionQuery(query)) = message.message
+        else {
+            panic!("expected an InteractionQuery");
+        };
+        let Some(pb::interaction_query::Query::WebSearchRequestQuery(request)) = query.query
+        else {
+            panic!("expected a WebSearchRequestQuery");
+        };
+        assert_eq!(request.args.unwrap().search_term, "lmarena leaderboard");
+    }
 }

--- a/server/src/cursor/tools/codec/render.rs
+++ b/server/src/cursor/tools/codec/render.rs
@@ -286,6 +286,20 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
             .and_then(Value::as_str)
             .map(str::to_string)
     };
+    // 与执行侧一致的参数别名兼容(如 Claude Code 习惯的 file_path),仅影响展示。
+    let aliased = |names: &[&str]| -> String {
+        names
+            .iter()
+            .find_map(|name| call.arguments.get(name).and_then(Value::as_str))
+            .unwrap_or_default()
+            .to_string()
+    };
+    let optional_aliased = |names: &[&str]| -> Option<String> {
+        names
+            .iter()
+            .find_map(|name| call.arguments.get(name).and_then(Value::as_str))
+            .map(str::to_string)
+    };
     match output.tool.as_mut() {
         Some(pb::tool_call::Tool::ShellToolCall(tool)) => {
             tool.description = optional("description");
@@ -299,7 +313,7 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
         }
         Some(pb::tool_call::Tool::DeleteToolCall(tool)) => {
             tool.args = Some(pb::DeleteArgs {
-                path: string("path"),
+                path: aliased(&["path", "file_path", "filePath"]),
                 tool_call_id: call.call_id.clone(),
             })
         }
@@ -321,7 +335,7 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
         }
         Some(pb::tool_call::Tool::ReadToolCall(tool)) => {
             tool.args = Some(pb::ReadToolArgs {
-                path: string("path"),
+                path: aliased(&["path", "file_path", "filePath"]),
                 offset: call
                     .arguments
                     .get("offset")
@@ -350,7 +364,7 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
         }
         Some(pb::tool_call::Tool::EditToolCall(tool)) => {
             let stream_content = if normalized(&call.name) == "write" {
-                optional("contents").unwrap_or_default()
+                optional_aliased(&["contents", "content"]).unwrap_or_default()
             } else {
                 optional("new_string").unwrap_or_default()
             };
@@ -358,7 +372,7 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
                 path: if normalized(&call.name) == "editnotebook" {
                     string("target_notebook")
                 } else {
-                    string("path")
+                    aliased(&["path", "file_path", "filePath"])
                 },
                 stream_content: Some(edit::normalize_newlines(&stream_content)),
             })
@@ -418,7 +432,7 @@ pub fn render_tool_call(call: &ToolCall, completed: bool) -> Result<pb::ToolCall
         }
         Some(pb::tool_call::Tool::WebSearchToolCall(tool)) => {
             tool.args = Some(pb::WebSearchArgs {
-                search_term: string("search_term"),
+                search_term: aliased(&["search_term", "query"]),
                 tool_call_id: call.call_id.clone(),
             })
         }

--- a/server/src/cursor/tools/codec/request.rs
+++ b/server/src/cursor/tools/codec/request.rs
@@ -22,6 +22,18 @@ pub fn request(id: u32, call: &ToolCall, context: &ExecContext) -> Result<pb::Ag
             .map(str::to_string)
             .ok_or_else(|| Error::Protocol(format!("{} is missing {name}", call.name)))
     };
+    // Claude 系模型常按 Claude Code 习惯输出别名参数(如 file_path),逐个回退兼容。
+    let string_aliased = |names: &[&str]| -> Result<String> {
+        for name in names {
+            if let Some(value) = call.arguments.get(name).and_then(Value::as_str) {
+                return Ok(value.to_string());
+            }
+        }
+        Err(Error::Protocol(format!(
+            "{} is missing {}",
+            call.name, names[0]
+        )))
+    };
     let optional_string = |name: &str| {
         call.arguments
             .get(name)
@@ -63,7 +75,7 @@ pub fn request(id: u32, call: &ToolCall, context: &ExecContext) -> Result<pb::Ag
             })
         }
         "read" => Message::ReadArgs(pb::ReadArgs {
-            path: string("path")?,
+            path: string_aliased(&["path", "file_path", "filePath"])?,
             tool_call_id: call.call_id.clone(),
             offset: int("offset"),
             limit: call
@@ -74,7 +86,7 @@ pub fn request(id: u32, call: &ToolCall, context: &ExecContext) -> Result<pb::Ag
             encoding_hint: optional_string("encoding_hint"),
         }),
         "delete" => Message::DeleteArgs(pb::DeleteArgs {
-            path: string("path")?,
+            path: string_aliased(&["path", "file_path", "filePath"])?,
             tool_call_id: call.call_id.clone(),
         }),
         "grep" => Message::GrepArgs(pb::GrepArgs {

--- a/server/src/cursor/tools/edit.rs
+++ b/server/src/cursor/tools/edit.rs
@@ -13,12 +13,12 @@ pub(crate) struct EditWrite {
 }
 
 pub(crate) fn path(call: &ToolCall) -> Result<String> {
-    let field = if normalized(&call.name) == "editnotebook" {
-        "target_notebook"
+    if normalized(&call.name) == "editnotebook" {
+        string(call, "target_notebook")
     } else {
-        "path"
-    };
-    string(call, field)
+        // Claude 系模型常按 Claude Code 习惯输出 file_path/filePath,做别名兼容。
+        string_any(call, &["path", "file_path", "filePath"])
+    }
 }
 
 pub(crate) fn execution_path(call: &ToolCall) -> Result<Option<String>> {
@@ -63,7 +63,10 @@ pub(crate) fn after_read(
     };
     let after = match normalized(&call.name).as_str() {
         "write" => {
-            normalize_newlines(&string(call, "contents").map_err(|error| error.to_string())?)
+            // Claude Code 习惯的 content 作为 contents 的别名兼容。
+            normalize_newlines(
+                &string_any(call, &["contents", "content"]).map_err(|error| error.to_string())?,
+            )
         }
         "strreplace" => replace_string(call, &before)?,
         "editnotebook" => edit_notebook(call, &before)?,
@@ -230,11 +233,19 @@ fn source_lines(value: &str) -> Vec<Value> {
 }
 
 fn string(call: &ToolCall, field: &str) -> Result<String> {
-    call.arguments
-        .get(field)
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .ok_or_else(|| Error::Protocol(format!("{} is missing {field}", call.name)))
+    string_any(call, &[field])
+}
+
+fn string_any(call: &ToolCall, fields: &[&str]) -> Result<String> {
+    for field in fields {
+        if let Some(value) = call.arguments.get(field).and_then(Value::as_str) {
+            return Ok(value.to_owned());
+        }
+    }
+    Err(Error::Protocol(format!(
+        "{} is missing {}",
+        call.name, fields[0]
+    )))
 }
 
 fn normalized(value: &str) -> String {

--- a/server/src/cursor/tools/tool_call_dispatch/interaction.rs
+++ b/server/src/cursor/tools/tool_call_dispatch/interaction.rs
@@ -88,12 +88,17 @@ fn start_web_search(
     search: WebSearch,
     pending: PendingInteraction,
 ) -> Result<()> {
-    let query = pending
-        .call
-        .arguments
-        .get("search_term")
-        .and_then(serde_json::Value::as_str)
-        .filter(|query| !query.trim().is_empty())
+    // Claude Code 习惯的 query 作为 search_term 的别名兼容。
+    let query = ["search_term", "query"]
+        .iter()
+        .find_map(|name| {
+            pending
+                .call
+                .arguments
+                .get(name)
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
         .ok_or_else(|| Error::Protocol("WebSearch is missing search_term".into()))?
         .to_string();
     tokio::spawn(async move {


### PR DESCRIPTION
# fix: accept common tool parameter aliases (file_path / content / query)

## 问题背景

Claude 系模型经 Claude Code 风格的 Anthropic 兼容中转端点（sub2api / kiro 类 relay）接入时，返回的 tool_use 常使用 Claude Code 的参数名习惯，与 BYOK 下发的 schema 参数名不一致：

- `Read` / `Write` / `StrReplace` / `Delete` 的路径参数返回为 `file_path`（schema 要求 `path`）
- `Write` 的内容参数返回为 `content`（schema 要求 `contents`）
- `WebSearch` 的查询参数返回为 `query`（schema 要求 `search_term`）

机理：根因是 Claude 的 Claude Code 训练先验；这类中转会注入 Claude Code 风格的 harness 提示词（甚至可能改写工具定义），把先验从概率性放大为高频。实测两路中转（kiro-rs 类、另一 sub2api 类）均高频复现；非 Claude 模型（如 kimi-k3）严格遵循 schema 从不触发。官方 Anthropic API 直连未见复现，但先验本身存在。

在 0.1.5 及更早版本，这类参数校验失败会以 `Error::Protocol` 向上传播，直接终止整个会话：

```
ERROR cursor_server::cursor::conversation::runtime: Cursor session failed
  request_id="e2465158-08b0-4886-939a-4173920cdece"
  error=protocol error: Read is missing path
```

实测一天内 35 次会话失败中 34 次都是这个错误。抓包确认上游实际返回的是合法 tool_use，只是参数名是 `file_path`：

```
event: content_block_delta
data: {"delta":{"partial_json":"{\"file_path\":\"/Users/.../xxx.hql\"}","type":"input_json_delta"},...}
```

## 0.1.6 之后的现状

0.1.6 引入的 `recover_validation_failure` 已经把这类错误降级为工具级失败并回传给模型，会话不再崩溃——这是一个很好的修复。

但参数名兼容仍未做（0.1.7 的 `server/src/cursor/tools/` 校验逻辑与之前一致），因此 Claude 系模型每次首次用错参数名时，仍会经历一次"失败 → 错误回传 → 模型自我纠正重试"的额外往返。本 PR 在此基础上进一步消除这类可预见的失败。

## 修复方案

执行侧对已知别名做回退兼容，**仅在主参数缺失时才回退**，不影响按 schema 正常出参的模型；报错信息仍指向主参数名：

| 工具 | 主参数 | 兼容别名 |
|---|---|---|
| `Read` / `Delete` / `Write` / `StrReplace` | `path` | `file_path`、`filePath` |
| `Write` | `contents` | `content` |
| `WebSearch` | `search_term` | `query` |

改动文件（共 5 个）：

- `server/src/cursor/tools/codec/request.rs`：执行侧 `Read`/`Delete` 别名回退
- `server/src/cursor/tools/edit.rs`：编辑流程 `path()` 与 `Write` 的 `contents` 别名回退
- `server/src/cursor/tools/codec/query.rs`：`WebSearch` 查询编码别名回退，并新增单元测试 `web_search_accepts_query_as_search_term_alias`
- `server/src/cursor/tools/tool_call_dispatch/interaction.rs`：`WebSearch` 交互路径别名回退
- `server/src/cursor/tools/codec/render.rs`：UI 展示侧同步兼容，避免工具卡片路径显示为空

## 验证

- `cargo test --package cursor-server --lib` 通过（仅有的 1 个失败 `provider::attempt::tests::request_transport_failure_is_one_failed_attempt` 在未打补丁的 v0.1.7 上同样失败，与本 PR 无关）
- 已基于 v0.1.6 / v0.1.7 本地编译桌面版并实际使用验证：Claude 系模型以 `file_path` 调 `Read`、以 `content` 调 `Write` 均可正常执行，按 schema 出参的模型（如 kimi-k3）行为无变化
